### PR TITLE
Jupyter notebook for MAS tutorial

### DIFF
--- a/machine-annotation-services/mas-tutorial.ipynb
+++ b/machine-annotation-services/mas-tutorial.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Machine Annotation Service\n",
+    "\n",
+    "In this document we will show how you can build a machine annotation service (MAS) which fully integrates with the DiSSCo infrastructure.\n",
+    "When these steps are followed, DiSSCo will be able to deploy, scale and run your MAS and make it available for all relevant digital objects.\n",
+    "\n",
+    "In general, we expect a MAS to consists of three steps:\n",
+    "1. Receive Digital Object\n",
+    "2. Work with the object, this could be anything from calling external APIs to data cleaning\n",
+    "3. Publish Annotations\n",
+    "4. Publish code as container image\n",
+    "\n",
+    "This tutorial with help with steps 1 and 3.\n",
+    "Step 2 is up to the provider to implement.\n",
+    "\n",
+    "For receiving and publishing data DiSSCo uses Kafka.\n",
+    "Kafka helps with the decoupling as well as the automatically scaling the applications.\n",
+    "The MAS will receive a message on its own queue, will be triggered to consume the message and publishes its results also on a queue.\n",
+    "From there the annotation will be created by the annotation-processing service and becomes available in the infrastructure.\n",
+    "\n",
+    "### Disclaimer\n",
+    "This Jupyter Notebook is used for explaining what is required of a MAS but it is not working code.\n",
+    "The development is currently in piloting phase.\n",
+    "We are testing different service to see if our set-up covers all use cases.\n",
+    "As our data models for the objects are still under development please contact sam.leeflang@naturalis.nl or wouter.addink@naturalis.nl for their latest version."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Receiving the digital object\n",
+    "Receiving the digital object can be done by subscribing to the Kafka queue.\n",
+    "The Kafka queue is created when the MAS is deployed and is specific for the MAS, no other application reads messages from this queue.\n",
+    "The details for the Kafka cluster as well as the Kafka queue name (called topic) is provided to the application through environmental variables.\n",
+    "- KAFKA_CONSUMER_TOPIC\n",
+    "- KAFKA_CONSUMER_GROUP\n",
+    "- KAFKA_CONSUMER_HOST\n",
+    "\n",
+    "In the first step we will also setup a Kafka publisher for which we use environmental values:\n",
+    "- KAFKA_PRODUCER_HOST\n",
+    "\n",
+    "The consumer and the producer can use different Kafka clusters.\n",
+    "However, in reality it is expected that this will always be the same."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "from kafka import KafkaConsumer, KafkaProducer\n",
+    "\n",
+    "consumer = KafkaConsumer(os.environ.get('KAFKA_CONSUMER_TOPIC'), group_id=os.environ.get('KAFKA_CONSUMER_GROUP'),\n",
+    "                         bootstrap_servers=[os.environ.get('KAFKA_CONSUMER_HOST')],\n",
+    "                         value_deserializer=lambda m: json.loads(m.decode('utf-8')),\n",
+    "                         enable_auto_commit=True)\n",
+    "producer = KafkaProducer(bootstrap_servers=[os.environ.get('KAFKA_PRODUCER_HOST')],\n",
+    "                         value_serializer=lambda m: json.dumps(m).encode('utf-8'))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "is_executing": true
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now that our consumer and producer are defined we can start consuming messages on the queue"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "for msg in consumer:\n",
+    "    json_value = msg.value\n",
+    "    object_data = json_value['data']"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Here we indicate that for each message of the consumer we would like to retrieve the value of the message (instead of the message headers or other information).\n",
+    "From this value we want to gather the data which contains all relevant data of the digital objects.\n",
+    "For full schema's of the objects please contact DiSSCo's developers."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Working the object\n",
+    "Now that we have the object data in memory we can start with creating new information about the object.\n",
+    "This could be anything, we could geo-reference against a range of external service by calling their API.\n",
+    "We could also follow a image url (of the Digital Media Object) and ran AI over the image.\n",
+    "Possibilities are endless.\n",
+    "The below example extracts additional metadata about the Digital Media Object, with the use of the library [Pillow] (https://pillow.readthedocs.io/en/stable/)."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from PIL import Image\n",
+    "from io import BytesIO\n",
+    "\n",
+    "img = Image.open(requests.get(image_uri, stream=True).raw)\n",
+    "img_file = BytesIO()\n",
+    "img.save(img_file, img.format, quality='keep')\n",
+    "additional_info = {'exif:PixelXDimension': img.width,\n",
+    "                   'exif:PixelYDimension': img.height,\n",
+    "                   'dcterms:format': img.format.lower(),\n",
+    "                   'dcterms:extent': str(round(img_file.tell() / 1000000, 2)) + 'MB'\n",
+    "                   }"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Publishing annotations\n",
+    "Now that we have extracted some additional data about the object we want to publish this data as annotations on the subject.\n",
+    "This means we have to mold the new data in the Annotation object.\n",
+    "The datamodel for the Annotation is currently being developed and will be explained here shortly.\n",
+    "After we create the Annotation object or objects we publish them to the Kafka topic"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "producer.send('annotation', annotation)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The first parameter indicates the topic name it needs to be published to which should be \"annotation\".\n",
+    "The second parameter is the annotation.\n",
+    "This can always be only one annotation, if a service generates multiple annotations it needs to publish these individually."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Publish as container image\n",
+    "Now we have all components in place we can package the code into a Docker container with a Docker Image.\n",
+    "An example of a Docker Image can be:"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# set base image (host OS)\n",
+    "FROM python:3.8-alpine\n",
+    "\n",
+    "# set the working directory in the container\n",
+    "WORKDIR /code\n",
+    "\n",
+    "# Create new user with UID\n",
+    "RUN adduser --disabled-password --gecos '' --system --uid 1001 python && chown -R python /code\n",
+    "\n",
+    "# Set user to newly created user\n",
+    "USER 1001\n",
+    "\n",
+    "# copy the dependencies file to the working directory\n",
+    "COPY requirements.txt .\n",
+    "\n",
+    "# install dependencies\n",
+    "RUN pip install -r requirements.txt\n",
+    "\n",
+    "# copy the content of the local src directory to the working directory\n",
+    "COPY main.py .\n",
+    "\n",
+    "# command to run on container start\n",
+    "CMD [ \"python\", \"main.py\" ]"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The creates a container image of the code which can then be published to a public image registry.\n",
+    "Let us know if you don't have your own image registry we could look if we can give you access to DiSSCo's image registry.\n",
+    "There are a couple of things to keep in mind when creating the image:\n",
+    "- The container won't have root access when run in the DiSSCo cluster\n",
+    "- The container won't have write access to the underlying file system\n",
+    "- The container will scale based on the amount of messages in the topic so should be stateless\n",
+    "- The container image needs a specific version, latest will not be accepted"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Conclusion\n",
+    "Feel free to reach out to us whenever you have a question or a use case of which you are unsure if it will fit.\n",
+    "For working examples see please check: https://github.com/DiSSCo/demo-enrichment-service-image\n",
+    "We will continuously update and improve this guide"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
A Jupyter notebook tutorial to explain what is required in a Machine Annotation Service.
This is an example, implementation can be found in: https://github.com/DiSSCo/demo-enrichment-service-image

The formatting in the PR looks strange as it just shows the text representation.
In the repo it should be able to show the cells and the code