### PR TITLE
Update virtualcollections.json

### DIFF
--- a/data-model/virtualcollections/virtualcollections.json
+++ b/data-model/virtualcollections/virtualcollections.json
@@ -1,1 +1,88 @@
-
+{
+  "type": "object",
+  "properties": {
+    "collection_type": {
+      "type": "string",
+      "enum": ["Dynamic Virtual Collection", "Static Virtual Collection"]
+    },
+    "id": {
+      "description": "A unique identifier for the collection. It can be a Handle for DVC or a DOI for SVC.",
+      "anyOf": [
+        {
+          "if": {
+            "properties": { "collection_type": { "const": "Dynamic Virtual Collection" } }
+          },
+          "then": {
+            "type": "string"
+          }
+        },
+        {
+          "if": {
+            "properties": { "collection_type": { "const": "Static Virtual Collection" } }
+          },
+          "then": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "filters": {
+      "type": "array",
+      "description": "Filters selected for the collection (applicable to DVC)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "filter_name": {
+            "type": "string",
+            "description": "Name or identifier/UUID for the filter"
+          },
+          "filter_value": {
+            "type": "string",
+            "description": "Value or configuration of the filter"
+          }
+        }
+      }
+    },
+    "digital_specimens": {
+      "type": "array",
+      "description": "Specimens included in the collection (applicable to SVC)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "PID of the digital specimen"
+          },
+          "version": {
+            "type": "string",
+            "description": "Version of the digital specimen included in the collection"
+          }
+        }
+      }
+    },
+    "is_private": {
+      "type": "boolean",
+      "description": "Indicates whether the collection is private or public"
+    }
+  },
+  "required": ["collection_type", "id", "is_private"],
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": { "collection_type": { "const": "Dynamic Virtual Collection" } }
+      },
+      "then": {
+        "required": ["filters"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "collection_type": { "const": "Static Virtual Collection" } }
+      },
+      "then": {
+        "required": ["digital_specimens"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
First draft, json schema for virtualcollections.

This JSON schema defines a data structure for describing virtual collections
- **collection_type**: A string that specifies the type of collection, which can be either "Dynamic Virtual Collection" or "Static Virtual Collection."

- **id**: A unique identifier for the collection. Its format depends on the type of collection, and it's either a Handle for Dynamic Virtual Collections or a DOI for Static Virtual Collections.

- **filters**: An array of objects describing the filters selected for the collection. This is applicable to Dynamic Virtual Collections (DVC) and includes filter names and their corresponding values.

- **digital_specimens**: An array of objects representing the digital specimens included in the collection. This is applicable to Static Virtual Collections (SVC) and contains DOIs and the versions. 

- **is_private**: A boolean value indicating whether the collection is private (true) or public (false).

The schema enforces specific requirements based on the type of collection:

- For Dynamic Virtual Collections (DVC), the "filters" property is required.

- For Static Virtual Collections (SVC), the "digital_specimens" property is required.