### PR TITLE
Run as nonroot

### DIFF
--- a/data-model/Dockerfile
+++ b/data-model/Dockerfile
@@ -1,7 +1,5 @@
 FROM nginxinc/nginx-unprivileged:alpine3.18-slim
 
-RUN
-
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 
 COPY ./annotations/0.1.0/schema/annotations.json schema-root/schemas/annotations/0.1.0/annotation.json

--- a/data-model/Dockerfile
+++ b/data-model/Dockerfile
@@ -1,8 +1,8 @@
-FROM nginx:stable-alpine3.17-slim
+FROM nginxinc/nginx-unprivileged:stable-bullseye-perl
 
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 
-COPY annotations/0.1.0/schema/annotations.json schema-root/schemas/annotations/0.1.0/annotation.json
+COPY ./annotations/0.1.0/schema/annotations.json schema-root/schemas/annotations/0.1.0/annotation.json
 
 COPY ./fdo-profiles/0.1.0/doi-kernel/schema/ schema-root/schemas/fdo-profiles/0.1.0/
 COPY ./fdo-profiles/0.1.0/handle-kernel/schema/ schema-root/schemas/fdo-profiles/0.1.0/

--- a/data-model/Dockerfile
+++ b/data-model/Dockerfile
@@ -1,4 +1,6 @@
-FROM nginxinc/nginx-unprivileged:stable-bullseye-perl
+FROM nginxinc/nginx-unprivileged:alpine3.18-slim
+
+RUN
 
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 

--- a/data-model/nginx/nginx.conf
+++ b/data-model/nginx/nginx.conf
@@ -1,5 +1,7 @@
 worker_processes auto;
 
+pid /tmp/nginx.pid;
+
 events {
 }
 


### PR DESCRIPTION
Run nginx as nonroot, using [nginx/unprivledged](https://github.com/nginxinc/docker-nginx-unprivileged)

From documentation: 

> This repo contains a series of Dockerfiles to create an NGINX Docker image that runs NGINX as a non root, unprivileged user

I'm not sure how this will interact with the deployment's "run as nonroot" directive. We may need to remove that line in the deployment if we get issues. 

Change in nginx.conf is a fix to allow the unprivledged container to run ([docker hub](https://hub.docker.com/r/nginxinc/nginx-unprivileged) describes the fix)

