### PR TITLE
Include internal annotation schema

### DIFF
--- a/data-model/Dockerfile
+++ b/data-model/Dockerfile
@@ -3,6 +3,7 @@ FROM nginxinc/nginx-unprivileged:alpine3.18-slim
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 
 COPY ./annotations/0.1.0/schema/annotations.json schema-root/schemas/annotations/0.1.0/annotation.json
+COPY ./annotations/0.1.0/schema/annotations_for_mas.json schema-root/schemas/annotations/0.1.0/annotation_for_mas.json
 
 COPY ./fdo-profiles/0.1.0/annotation/schema/ schema-root/schemas/fdo-profiles/0.1.0/
 COPY ./fdo-profiles/0.1.0/digital-specimen/schema/ schema-root/schemas/fdo-profiles/0.1.0/

--- a/data-model/annotations/0.1.0/schema/annotations_for_mas.json
+++ b/data-model/annotations/0.1.0/schema/annotations_for_mas.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "description": "Schema specific to Machine Annotation Services providing information to DiSSCo.",
+  "properties": {
+    "ods:id": {
+      "type": "string"
+    },
+    "ods:jobId": {
+      "type": "string",
+      "description": "Handle of the job record, if the annotation was produced by a Machine Annotation Service",
+      "pattern": "https:\/\/hdl.handle.net\/[^\/]+\/(.){3}-(.){3}-(.){3}"
+    },
+    "rdf:type": {
+      "const": "Annotation"
+    },
+    "oa:motivation": {
+      "enum": [
+        "ods:adding",
+        "oa:assessing",
+        "oa:editing",
+        "oa:commenting"
+      ]
+    },
+    "oa:motivatedBy": {
+      "type": "string"
+    },
+    "oa:creator": {
+      "type": "object",
+      "properties": {
+        "ods:type": {
+          "type": "string"
+        },
+        "foaf:name": {
+          "type": "string"
+        },
+        "ods:id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "ods:id",
+        "ods:type"
+      ]
+    },
+    "dcterms:created": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "oa:target": {
+      "type": "object",
+      "properties": {
+        "ods:id": {
+          "type": "string"
+        },
+        "ods:type": {
+          "type": "string"
+        },
+        "oa:selector": {
+          "type": "object",
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "ods:type": {
+                  "const": "FieldSelector"
+                },
+                "ods:field": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "ods:type",
+                "ods:field"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ods:type": {
+                  "const": "ClassSelector"
+                },
+                "oa:class": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "ods:type",
+                "oa:class"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ods:type": {
+                  "const": "FragmentSelector"
+                },
+                "ac:hasRoi": {
+                  "type": "object",
+                  "properties": {
+                    "ac:xFrac": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "ac:yFrac": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "ac:widthFrac": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "ac:heightFrac": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  },
+                  "required": [
+                    "ac:xFrac",
+                    "ac:yFrac",
+                    "ac:widthFrac",
+                    "ac:heightFrac"
+                  ]
+                },
+                "dcterms:conformsTo": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "ods:type",
+                "ac:hasRoi"
+              ]
+            }
+          ]
+        }
+      },
+      "required": [
+        "ods:id",
+        "ods:type"
+      ]
+    },
+    "oa:body": {
+      "type": "object",
+      "properties": {
+        "ods:type": {
+          "type": "string"
+        },
+        "oa:value": {
+          "type": "array"
+        },
+        "dcterms:reference": {
+          "type": "string"
+        },
+        "ods:score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      },
+      "required": [
+        "ods:type",
+        "oa:value"
+      ]
+    },
+    "schema.org:aggregateRating": {
+      "type": "object",
+      "properties": {
+        "ods:type": {
+          "type": "string"
+        },
+        "schema.org:ratingCount": {
+          "type": "number"
+        },
+        "schema.org:ratingValue": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "ods:type",
+        "schema.org:ratingCount",
+        "schema.org:ratingValue"
+      ]
+    },
+    "placeInBatch": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "rdf:type",
+    "oa:motivation",
+    "oa:target",
+    "oa:body",
+    "oa:creator"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Adds internal schema for communication from MAS to Processing service. This is the schema annotatons coming from MASs must adhere to when communicating with the core dissco infrastructure. 
- Some fields are assigned by processing service (version, generator), so they are omitted from this schema.
- placeInBatch: parameter used in internal communication between MAS and processing service for batch annotations. NOT in annotation data model.