### PR TITLE
Add ods:scientificNameHtmlLabel to identification

### DIFF
--- a/data-model/digitalobjects/0.1.0/digital-specimens/schema/identifications.json
+++ b/data-model/digitalobjects/0.1.0/digital-specimens/schema/identifications.json
@@ -118,6 +118,13 @@
               "Roptrocerus typographi (Györfi, 1952)"
             ]
           },
+          "ods:scientificNameHtmlLabel": {
+            "type": "string",
+            "description": "A Hyper Text Markup Language (HTML) representation of the scientific name. Includes correct formatting of the name.",
+            "examples": [
+              "<i>Absidia ginsan</i> Komin. et al., 1952"
+            ]
+          },
           "dwc:scientificNameAuthorship": {
             "type": "string",
             "description": "https://rs.tdwg.org/dwc/terms/scientificNameAuthorship",


### PR DESCRIPTION
Need an additional field to store the html representation of the scientificName.
Formatting has been taken over from CoL.