### PR TITLE
Align otherSpecimenIds

### DIFF
--- a/data-model/fdo-profiles/0.1.0/digital-specimen/schema/digital-specimen-request.json
+++ b/data-model/fdo-profiles/0.1.0/digital-specimen/schema/digital-specimen-request.json
@@ -2,7 +2,7 @@
   "$id": "ttps://schemas.dissco.tech/schemas/fdo-profiles/0.1.0/digital-specimen-request.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "FDO Profile for Digital Specimens",
-  "$comment":"FDO Profile Version 0.1.0",
+  "$comment": "FDO Profile Version 0.1.0",
   "allof": [
     {
       "$ref": "https://schemas.dissco.tech/schemas/fdo-profiles/0.1.0/handle-request.json"
@@ -57,13 +57,10 @@
       "items": {
         "type": "object",
         "properties": {
-          "id": {
+          "identifierValue": {
             "type": "string"
           },
-          "idType": {
-            "type": "string"
-          },
-          "idName": {
+          "identifierType": {
             "type": "string"
           }
         }

--- a/data-model/fdo-profiles/0.1.0/digital-specimen/schema/digital-specimen.json
+++ b/data-model/fdo-profiles/0.1.0/digital-specimen/schema/digital-specimen.json
@@ -64,13 +64,10 @@
     "items": {
       "type": "object",
       "properties": {
-        "id": {
+        "identifierValue": {
           "type": "string"
         },
-        "idType": {
-          "type": "string"
-        },
-        "idName": {
+        "identifierType": {
           "type": "string"
         }
       }


### PR DESCRIPTION
the fdo profile field "otherSpecimenIds" needs to align with the digital specimen field "Identifiers"

[Jira](https://naturalis.atlassian.net/browse/DD-972?atlOrigin=eyJpIjoiNDRkZjgyNGUzZmI2NDAyYTkyZDhmMDdlOGFkMjdhZDkiLCJwIjoiaiJ9)

Related PRs
- [Handle](https://github.com/DiSSCo/handle-manager/pull/75)
- [Processor](https://github.com/DiSSCo/dissco-core-digital-specimen-processor/pull/45)