### PR TITLE
Digital Specimen update to 0.2.0

### DIFF
--- a/data-model/Dockerfile
+++ b/data-model/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:alpine3.18-slim
+FROM nginxinc/nginx-unprivileged:1.26-alpine
 
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 
@@ -22,3 +22,4 @@ COPY digitalobjects/0.1.0/digital-specimens/schema schema-root/schemas/digitalob
 COPY digitalobjects/0.1.0/shared-models/schema schema-root/schemas/digitalobjects/0.1.0/shared-models
 COPY digitalobjects/0.1.0/digital-media-objects/schema schema-root/schemas/digitalobjects/0.1.0/digital-media-objects
 
+COPY digitalobjects/0.2.0/digital-specimens/schema schema-root/schemas/digitalobjects/0.2.0/digital-specimens

--- a/data-model/digitalobjects/0.2.0/RELEASE_NOTES.md
+++ b/data-model/digitalobjects/0.2.0/RELEASE_NOTES.md
@@ -1,0 +1,15 @@
+# Release Notes
+
+New version 0.0.2 for some of the files to include new terms.
+
+## Verbatim Terms
+Verbatim terms added such as `dwc:verbatimLocality` and `dwc:verbatimEventDate`.
+The verbatim terms will be filled with the verbatim fields but not used for any further processing.
+They are mainly used to keep the original value on the label.
+The non-verbatim fields will be used for further processing.
+For the non-verbatim fields we will first check the non-verbatim field, if this is not available we will take the verbatim field.
+For example, to fill the `dwc:locality` field we will first check the `dwc:locality` field, if this is empty we will take the `dwc:verbatimLocality` field.
+
+## ID fields
+MIDS 3 requires several ID fields to be present.
+These were not all included in the 0.1.0 version.

--- a/data-model/digitalobjects/0.2.0/RELEASE_NOTES.md
+++ b/data-model/digitalobjects/0.2.0/RELEASE_NOTES.md
@@ -13,3 +13,8 @@ For example, to fill the `dwc:locality` field we will first check the `dwc:local
 ## ID fields
 MIDS 3 requires several ID fields to be present.
 These were not all included in the 0.1.0 version.
+
+## Updated class names
+Updated class names to reuse Darwin Core classes as much as possible.
+Where it is not possible to reuse Darwin Core we prefixed them with `???:`.
+Made them singular and camelCase.

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/digital-specimen.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/digital-specimen.json
@@ -1,0 +1,343 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/digital-specimen.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment":"DigitalObject Version 0.2.0",
+  "type": "object",
+  "properties": {
+    "ods:id": {
+      "type": "string",
+      "description": "The unique digital identifier of the object",
+      "pattern": "https:\/\/doi.org\/10.22\/(.){3}-(.){3}-(.){3}",
+      "examples": [
+        "https://doi.org/10.22/XXX-XXX-XXX"
+      ]
+    },
+    "ods:version": {
+      "type": "integer",
+      "description": "The version of the object, each change generates a new version",
+      "minimum": 1,
+      "examples": [
+        1
+      ]
+    },
+    "ods:created": {
+      "type": "string",
+      "description": "The timestamp that the object version was created in DiSSCo",
+      "format": "date-time",
+      "examples": [
+        "2023-10-02T12:31:34.806Z"
+      ]
+    },
+    "ods:type": {
+      "type": "string",
+      "description": "The FDO type of the object",
+      "$comment": "Unclear what value goes here"
+    },
+    "ods:midsLevel": {
+      "type": "integer",
+      "description": "The MIDS level of the object, see https://www.tdwg.org/community/cd/mids/",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "ods:normalisedPhysicalSpecimenId": {
+      "type": "string",
+      "description": "The physical specimen identifier of the object. When locally unique this is a combination between source-system-id and the local identifier"
+    },
+    "ods:physicalSpecimenId": {
+      "type": "string",
+      "description": "The physical specimen identifier of the object. Taken over as-is"
+    },
+    "ods:physicalSpecimenIdType": {
+      "type": "string",
+      "description": "To indicate if the physical identifier is globally unique or locally unique",
+      "enum": [
+        "Resolvable",
+        "Global",
+        "Local"
+      ],
+      "$comment": "Do we need to further distinguish the identifier, for example add 'RESOLVABLE'"
+    },
+    "ods:topicOrigin": {
+      "type": "string",
+      "description": "The topic origin of the specimen",
+      "enum": [
+        "Natural",
+        "Human-made",
+        "Mixed origin",
+        "Unclassified"
+      ],
+      "example": [
+        "Natural"
+      ],
+      "$comment": "Do we need to add 'UNKNOWN'?"
+    },
+    "ods:topicDomain": {
+      "type": "string",
+      "description": "The topic domain of the specimen",
+      "enum": [
+        "Life",
+        "Environment",
+        "Earth System",
+        "Extraterrestrial",
+        "Cultural Artefacts",
+        "Archive Material",
+        "Unclassified"
+      ],
+      "example": [
+        "Life"
+      ],
+      "$comment": "Do we need to add 'UNKNOWN'?"
+    },
+    "ods:topicDiscipline": {
+      "type": "string",
+      "description": "The topic discipline of the specimen",
+      "enum": [
+        "Anthropology",
+        "Botany",
+        "Astrogeology",
+        "Geology",
+        "Microbiology",
+        "Palaeontology",
+        "Zoology",
+        "Ecology",
+        "Other Biodiversity",
+        "Other Geodiversity",
+        "Unclassified"
+      ],
+      "example": [
+        "Botany"
+      ],
+      "$comment": "Do we need to add 'UNKNOWN'?"
+    },
+    "ods:markedAsType": {
+      "type": "boolean",
+      "description": "The specimen is marked as a type specimen"
+    },
+    "ods:hasMedia": {
+      "type": "boolean",
+      "description": "Indicates if there are any media objects attached to this specimen"
+    },
+    "ods:specimenName": {
+      "type": "string",
+      "description": "The accepted specimen name of the digital specimen",
+      "example": [
+        "Roptrocerus typographi (Györfi, 1952)"
+      ]
+    },
+    "ods:sourceSystem": {
+      "type": "string",
+      "description": "The handle to the source system object which retrieved the data from the CMS",
+      "pattern": "https:\/\/hdl.handle.net\/20.5000.1025\/(.){3}-(.){3}-(.){3}"
+    },
+    "ods:livingOrPreserved": {
+      "type": "string",
+      "description": "Whether the specimen is living or preserved",
+      "enum": [
+        "Living",
+        "Preserved"
+      ]
+    },
+    "dcterms:license": {
+      "type": "string",
+      "description": "License for the metadata of the physical specimen",
+      "$comment": "Determine available licenses"
+    },
+    "dcterms:modified": {
+      "type": "string",
+      "description": "Modification date for specimen information"
+    },
+    "dwc:basisOfRecord": {
+      "type": "string",
+      "description": "The basis for the record",
+      "$comment": "Switch to enumeration as this is a limited list"
+    },
+    "dwc:preparations": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/preparations",
+      "example": [
+        "fossil"
+      ]
+    },
+    "dwc:disposition": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/disposition",
+      "examples": [
+        "in collection"
+      ]
+    },
+    "dwc:institutionCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/institutionCode",
+      "examples": [
+        "MNF"
+      ]
+    },
+    "dwc:institutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier, based on https://rs.tdwg.org/dwc/terms/institutionID",
+      "examples": [
+        "https://ror.org/015hz7p22"
+      ],
+      "$comment": "Add format for ROR or Wikidata ID"
+    },
+    "dwc:institutionName": {
+      "type": "string",
+      "description": "Full museum name according to ROR or Wikidata",
+      "examples": [
+        "National Museum of Natural History"
+      ],
+      "$comment": "Not part of DWC or the GBIF UM"
+    },
+    "dwc:collectionCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/collectionCode",
+      "examples": [
+        "EBIRD"
+      ],
+      "$comment": "Cetaf collection code?"
+    },
+    "dwc:collectionId": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/collectionID",
+      "examples": [
+        "https://www.gbif.org/grscicoll/collection/fbd3ed74-5a21-4e01-b86a-33d36f032d9c"
+      ],
+      "$comment": "Are we going to use GRSciColl or Cetaf collection identifiers?"
+    },
+    "dwc:informationWithheld": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/informationWithheld",
+      "examples": [
+        "location information not given for endangered species"
+      ],
+      "$comment": "Feels like this field should be true or false and another field should contain the explanation"
+    },
+    "dwc:dataGeneralizations": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/dataGeneralizations",
+      "examples": [
+        "Coordinates generalized from original GPS coordinates to the nearest half degree grid cell."
+      ]
+    },
+    "dwc:ownerInstitutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier for the owning institution",
+      "$comment": "DWC only has ownerInstitutionCode, however code is not an (resolvable identifier)",
+      "examples": [
+        "https://ror.org/03wkt5x30"
+      ]
+    },
+    "dwc:recordedBy": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedBy",
+      "examples": [
+        "José E. Crespo"
+      ]
+    },
+    "dwc:recordedById": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedByID",
+      "examples": [
+        "https://orcid.org/0000-0002-1825-0097"
+      ]
+    },
+    "???:recordedByAgent": {
+      "$ref": "agent.json",
+      "$comment": "Is this an option for the agent instead of adding a list?"
+    },
+    "dwc:datasetName": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/datasetName",
+      "examples": [
+        "Hummingbirds"
+      ]
+    },
+    "dcterms:accessRights": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/accessRights",
+      "examples": [
+        "not-for-profit use only"
+      ]
+    },
+    "dcterms:rightsHolder": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/rightsHolder",
+      "examples": [
+        "Museu de História Natural e da Ciência da Universidade do Porto"
+      ]
+    },
+    "dwc:verbatimLabel": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimLabel",
+      "examples": [
+        "ILL: Union Co. Wolf Lake by Powder Plant Bridge. 1 March 1975 Coll. S. Ketzler, S. Herbert\n\nMonotoma longicollis 4 ♂ Det TC McElrath 2018\n\nINHS Insect Collection 456782"
+      ]
+    },
+    "materialEntity": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/material-entity.json"
+      }
+    },
+    "dwc:identification": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/identifications.json"
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/assertions.json"
+      }
+    },
+    "occurrences": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/occurrences.json"
+      }
+    },
+    "entityRelationships": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/entity-relationships.json"
+      }
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/citations.json"
+      }
+    },
+    "identifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/identifiers.json"
+      }
+    },
+    "chronometricAge": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/digital-specimens/chronometric-age.json"
+      }
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"
+      }
+    }
+  },
+  "required": [
+    "ods:id",
+    "ods:version",
+    "ods:type",
+    "ods:created",
+    "ods:midsLevel",
+    "ods:physicalSpecimenId",
+    "ods:physicalSpecimenIdType",
+    "ods:sourceSystem",
+    "dcterms:license",
+    "???:institutionId"
+  ]
+}

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/digital-specimen.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/digital-specimen.json
@@ -68,8 +68,7 @@
       ],
       "example": [
         "Natural"
-      ],
-      "$comment": "Do we need to add 'UNKNOWN'?"
+      ]
     },
     "ods:topicDomain": {
       "type": "string",
@@ -85,8 +84,7 @@
       ],
       "example": [
         "Life"
-      ],
-      "$comment": "Do we need to add 'UNKNOWN'?"
+      ]
     },
     "ods:topicDiscipline": {
       "type": "string",
@@ -106,8 +104,7 @@
       ],
       "example": [
         "Botany"
-      ],
-      "$comment": "Do we need to add 'UNKNOWN'?"
+      ]
     },
     "ods:markedAsType": {
       "type": "boolean",
@@ -241,10 +238,6 @@
         "https://orcid.org/0000-0002-1825-0097"
       ]
     },
-    "???:recordedByAgent": {
-      "$ref": "agent.json",
-      "$comment": "Is this an option for the agent instead of adding a list?"
-    },
     "dwc:datasetName": {
       "type": "string",
       "description": "https://rs.tdwg.org/dwc/terms/datasetName",
@@ -273,55 +266,55 @@
         "ILL: Union Co. Wolf Lake by Powder Plant Bridge. 1 March 1975 Coll. S. Ketzler, S. Herbert\n\nMonotoma longicollis 4 ♂ Det TC McElrath 2018\n\nINHS Insect Collection 456782"
       ]
     },
-    "materialEntity": {
+    "dwc:MaterialEntity": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/material-entity.json"
       }
     },
-    "dwc:identification": {
+    "dwc:Identification": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/identifications.json"
       }
     },
-    "assertions": {
+    "???:Assertion": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/assertions.json"
       }
     },
-    "occurrences": {
+    "dwc:Occurrence": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/occurrences.json"
       }
     },
-    "entityRelationships": {
+    "???:EntityRelationship": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/entity-relationships.json"
       }
     },
-    "citations": {
+    "???:Citation": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/citations.json"
       }
     },
-    "identifiers": {
+    "???:Identifier": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/identifiers.json"
       }
     },
-    "chronometricAge": {
+    "???:ChronometricAge": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/digital-specimens/chronometric-age.json"
       }
     },
-    "agents": {
+    "???:Agent": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"
@@ -338,6 +331,6 @@
     "ods:physicalSpecimenIdType",
     "ods:sourceSystem",
     "dcterms:license",
-    "???:institutionId"
+    "dwc:institutionId"
   ]
 }

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/events.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/events.json
@@ -1,0 +1,122 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/events.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "DigitalObject Version 0.2.0",
+  "type": "object",
+  "properties": {
+    "???:eventName": {
+      "type": "string",
+      "comment": "Not sure what this field means"
+    },
+    "dwc:fieldNumber": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/fieldNumber",
+      "examples": [
+        "RV Sol 87-03-08"
+      ]
+    },
+    "dwc:recordNumber": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordNumber",
+      "examples": [
+        "OPP 7101"
+      ]
+    },
+    "dwc:eventDate": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/eventDate",
+      "examples": [
+        "1963-03-08T14:07-0600"
+      ]
+    },
+    "dwc:verbatimEventDate": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimEventDate",
+      "examples": [
+        "Marzo 2002"
+      ]
+    },
+    "dwc:year": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/year",
+      "examples": [
+        2008
+      ]
+    },
+    "dwc:month": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/month",
+      "examples": [
+        12
+      ]
+    },
+    "dwc:day": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/day",
+      "examples": [
+        29
+      ]
+    },
+    "dwc:habitat": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/habitat",
+      "examples": [
+        "savanna"
+      ],
+      "$comment": "Is this necessary for specimens"
+    },
+    "???:protocolDescription": {
+      "type": "string",
+      "comment": "Not sure what this field means"
+    },
+    "dwc:sampleSizeValue": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/sampleSizeValue",
+      "examples": [
+        "5"
+      ]
+    },
+    "dwc:sampleSizeUnit": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/sampleSizeUnit",
+      "examples": [
+        "meters"
+      ]
+    },
+    "???:eventEffort": {
+      "type": "string",
+      "comment": "Not sure what this field means"
+    },
+    "dwc:fieldNotes": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/fieldNotes",
+      "examples": [
+        "Notes available in the Grinnell-Miller Library"
+      ]
+    },
+    "dwc:eventRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/eventRemarks",
+      "examples": [
+        "After the recent rains the river is nearly at flood stage"
+      ]
+    },
+    "???:collectorName": {
+      "type": "string",
+      "$comment": "Not part of DWC or the UM?"
+    },
+    "???:collectorId": {
+      "type": "string",
+      "$comment": "Not part of DWC or the UM?"
+    },
+    "location": {
+      "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/location.json"
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"
+      }
+    }
+  }
+}

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/events.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/events.json
@@ -65,9 +65,12 @@
       ],
       "$comment": "Is this necessary for specimens"
     },
-    "???:protocolDescription": {
+    "eco:protocolDescriptions": {
       "type": "string",
-      "comment": "Not sure what this field means"
+      "description": "https://rs.tdwg.org/eco/terms/protocolDescriptions",
+      "examples": [
+        "Three conventional harp traps (3.2m ht x 2.2m w) were established in flight path zones for a period of 4 hrs at dawn and dusk for a total of 10 trap nights. Traps were visited on an hourly basis during each deployment period and the trap catch recorded for species, size, weight, sex, age and maternal status."
+      ]
     },
     "dwc:sampleSizeValue": {
       "type": "string",
@@ -109,10 +112,10 @@
       "type": "string",
       "$comment": "Not part of DWC or the UM?"
     },
-    "location": {
+    "dcterms:Location": {
       "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/location.json"
     },
-    "agents": {
+    "???:Agent": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/identifications.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/identifications.json
@@ -96,13 +96,13 @@
       "description": "Unclear yet",
       "$comment": "Unknown what this field should be"
     },
-    "citations": {
+    "???:Citation": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/citations.json"
       }
     },
-    "agents": {
+    "???:Agent": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/identifications.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/identifications.json
@@ -1,0 +1,365 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/identifications.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "DigitalObject Version 0.2.0",
+  "type": "object",
+  "properties": {
+    "dwc:identificationID": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identificationID",
+      "examples": [
+        "9992"
+      ]
+    },
+    "???:identificationType": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "???:taxonFormula": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "dwc:verbatimIdentification": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimIdentification",
+      "examples": [
+        "Peromyscus sp."
+      ]
+    },
+    "dwc:typeStatus": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/typeStatus",
+      "example": [
+        "holotype"
+      ],
+      "$comment": "Unclear if we can make this an enumeration, which values?"
+    },
+    "dwc:identifiedBy": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identifiedBy",
+      "example": [
+        "James L. Patton"
+      ]
+    },
+    "dwc:identifiedById": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identifiedByID",
+      "example": [
+        "https://orcid.org/0000-0002-1825-0097"
+      ]
+    },
+    "dwc:dateIdentified": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/dateIdentified",
+      "example": [
+        "2009-02-20T08:40Z"
+      ]
+    },
+    "dwc:identificationReferences": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identificationReferences",
+      "example": [
+        "Aves del Noroeste Patagonico. Christie et al. 2004."
+      ],
+      "$comment": "Is this still needed or can we add the citation object here?"
+    },
+    "dwc:identificationVerificationStatus": {
+      "type": "boolean",
+      "description": "If this is the accepted identification, based on https://rs.tdwg.org/dwc/terms/identificationVerificationStatus",
+      "example": [
+        true
+      ]
+    },
+    "dwc:identificationRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identificationRemarks",
+      "examples": [
+        "Distinguished between Anthus correndera and Anthus hellmayri based on the comparative lengths of the uñas."
+      ]
+    },
+    "dwc:identificationQualifier": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identificationQualifier",
+      "examples": [
+        "cf. var. oxyadenia"
+      ]
+    },
+    "???:typeDesignationType": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "???:typeDesignatedBy": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/citations.json"
+      }
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"
+      }
+    },
+    "taxonIdentifications": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dwc:taxonID": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/taxonID",
+            "examples": [
+              "https://www.gbif.org/species/212"
+            ]
+          },
+          "dwc:scientificName": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/scientificName",
+            "examples": [
+              "Roptrocerus typographi (Györfi, 1952)"
+            ]
+          },
+          "dwc:scientificNameId": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/scientificNameID",
+            "examples": [
+              "urn:lsid:ipni.org:names:37829-1:1.3"
+            ]
+          },
+          "ods:scientificNameHtmlLabel": {
+            "type": "string",
+            "description": "A Hyper Text Markup Language (HTML) representation of the scientific name. Includes correct formatting of the name.",
+            "examples": [
+              "<i>Absidia ginsan</i> Komin. et al., 1952"
+            ]
+          },
+          "dwc:scientificNameAuthorship": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/scientificNameAuthorship",
+            "examples": [
+              "(Torr.) J.T. Howell"
+            ]
+          },
+          "dwc:nameAccordingTo": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/nameAccordingTo",
+            "examples": [
+              "Plants of the World Online"
+            ]
+          },
+          "dwc:namePublishedInYear": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/namePublishedInYear",
+            "examples": [
+              "2022"
+            ]
+          },
+          "dwc:taxonRank": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/taxonRank",
+            "examples": [
+              "species"
+            ]
+          },
+          "dwc:verbatimTaxonRank": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/verbatimTaxonRank",
+            "examples": [
+              "Agamospecies"
+            ]
+          },
+          "???:taxonSource": {
+            "type": "string",
+            "description": "Unclear yet",
+            "$comment": "Unknown what this field should be"
+          },
+          "dwc:taxonRemarks": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/taxonRemarks",
+            "examples": [
+              "this name is a misspelling in common use"
+            ]
+          },
+          "dwc:kingdom": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/kingdom",
+            "examples": [
+              "animalia"
+            ],
+            "$comment": "Could be an enum?"
+          },
+          "dwc:phylum": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/phylum",
+            "examples": [
+              "Chordata"
+            ]
+          },
+          "dwc:class": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/class",
+            "examples": [
+              "Hepaticopsida"
+            ]
+          },
+          "dwc:order": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/order",
+            "examples": [
+              "Carnivora"
+            ]
+          },
+          "dwc:family": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/family",
+            "examples": [
+              "Felidae"
+            ]
+          },
+          "dwc:subfamily": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/subfamily",
+            "examples": [
+              "Orchidoideae"
+            ]
+          },
+          "dwc:genus": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/genus",
+            "examples": [
+              "Puma"
+            ]
+          },
+          "dwc:specificEpithet": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/specificEpithet",
+            "examples": [
+              "concolor"
+            ]
+          },
+          "dwc:taxonomicStatus": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/taxonomicStatus",
+            "$comment": "Might become an enum",
+            "examples": [
+              "accepted"
+            ]
+          },
+          "dwc:nomenclaturalCode": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/nomenclaturalCode",
+            "$comment": "Might become an enum",
+            "examples": [
+              "ICBN"
+            ]
+          },
+          "dwc:vernacularName": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/vernacularName",
+            "examples": [
+              "Meerval | Wels | Catfish | Silure glane | Wels | Waller | Siluro | Malle"
+            ]
+          },
+          "dwc:subgenus": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/subgenus",
+            "examples": [
+              "Strobus"
+            ]
+          },
+          "dwc:acceptedNameUsage": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/acceptedNameUsage",
+            "examples": [
+              "Tamias minimus"
+            ]
+          },
+          "dwc:acceptedNameUsageID": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/acceptedNameUsageID",
+            "examples": [
+              "6W3C4"
+            ]
+          },
+          "dwc:cultivarEpithet": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/cultivarEpithet",
+            "examples": [
+              "King Edward"
+            ]
+          },
+          "dwc:genericName": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/genericName",
+            "examples": [
+              "Felis"
+            ]
+          },
+          "dwc:infragenericEpithet": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/infragenericEpithet",
+            "examples": [
+              "Abacetillus"
+            ]
+          },
+          "dwc:infraspecificEpithet": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/infraspecificEpithet",
+            "examples": [
+              "oxyadenia"
+            ]
+          },
+          "dwc:nomenclaturalStatus": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/nomenclaturalStatus",
+            "examples": [
+              "nom. illeg."
+            ]
+          },
+          "dwc:originalNameUsage": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/originalNameUsage",
+            "examples": [
+              "Pinus abies"
+            ]
+          },
+          "dwc:subtribe": {
+            "type": "string",
+            "description": "http://rs.tdwg.org/dwc/terms/subtribe",
+            "examples": [
+              "Plotinini"
+            ]
+          },
+          "dwc:superfamily": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/superfamily",
+            "examples": [
+              "Cerithioidea"
+            ]
+          },
+          "dwc:tribe": {
+            "type": "string",
+            "description": "https://rs.tdwg.org/dwc/terms/tribe",
+            "examples": [
+              "Arethuseae"
+            ]
+          }
+        },
+        "required": [
+          "dwc:scientificName"
+        ]
+      }
+    }
+  },
+  "required": [
+    "dwc:identificationVerificationStatus"
+  ]
+}

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/location.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/location.json
@@ -173,7 +173,7 @@
         "under water since 2005"
       ]
     },
-    "georeference": {
+    "???:GeoReference": {
       "type": "object",
       "properties": {
         "dwc:verbatimCoordinates": {
@@ -326,7 +326,7 @@
         }
       }
     },
-    "geologicalContext": {
+    "dwc:GeologicalContext": {
       "type": "object",
       "properties": {
         "dwc:earliestEonOrLowestEonothem": {

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/location.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/location.json
@@ -1,0 +1,466 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/location.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment":"DigitalObject Version 0.2.0",
+  "type": "object",
+  "properties": {
+    "dwc:locationID": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/locationID",
+      "examples": [
+        "https://opencontext.org/subjects/768A875F-E205-4D0B-DE55-BAB7598D0FD1"
+      ]
+    },
+    "dwc:continent": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/continent",
+      "examples": [
+        "Africa"
+      ]
+    },
+    "dwc:waterBody": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/waterBody",
+      "examples": [
+        "Baltic Sea"
+      ]
+    },
+    "dwc:islandGroup": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/islandGroup",
+      "examples": [
+        "Seychelles"
+      ]
+    },
+    "dwc:island": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/island",
+      "examples": [
+        "Vancouver"
+      ]
+    },
+    "dwc:country": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/country",
+      "examples": [
+        "Colombia"
+      ]
+    },
+    "dwc:countryCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/countryCode",
+      "examples": [
+        "SV"
+      ]
+    },
+    "dwc:stateProvince": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/stateProvince",
+      "examples": [
+        "Montana"
+      ]
+    },
+    "dwc:county": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/county",
+      "examples": [
+        "Los Lagos"
+      ]
+    },
+    "dwc:municipality": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/municipality",
+      "examples": [
+        "Holzminden"
+      ]
+    },
+    "dwc:locality": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/locality",
+      "examples": [
+        "Zeeuws-Vlaanderen, Hulst, Braakman"
+      ]
+    },
+    "dwc:verbatimLocality": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimLocality",
+      "examples": [
+        "25 km NNE Bariloche por R. Nac. 237"
+      ]
+    },
+    "dwc:minimumElevationInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/minimumElevationInMeters",
+      "examples": [
+        -100
+      ]
+    },
+    "dwc:higherGeography": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/higherGeography",
+      "examples": [
+        "Britain and Ireland"
+      ]
+    },
+    "dwc:maximumElevationInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/maximumElevationInMeters",
+      "examples": [
+        205
+      ]
+    },
+    "dwc:verbatimElevation": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimElevation",
+      "examples": [
+        "100 - 200 m"
+      ]
+    },
+    "dwc:minimumDistanceAboveSurfaceInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/minimumDistanceAboveSurfaceInMeters",
+      "examples": [
+        -1,
+        5
+      ]
+    },
+    "dwc:maximumDistanceAboveSurfaceInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/maximumDistanceAboveSurfaceInMeters",
+      "examples": [
+        4.2
+      ]
+    },
+    "dwc:minimumDepthInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/minimumDepthInMeters",
+      "examples": [
+        50
+      ]
+    },
+    "dwc:maximumDepthInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/maximumDepthInMeters",
+      "examples": [
+        340
+      ]
+    },
+    "dwc:verbatimDepth": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimDepth",
+      "examples": [
+        "100-200 m"
+      ]
+    },
+    "dwc:verticalDatum": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verticalDatum",
+      "examples": [
+        "EGM84"
+      ]
+    },
+    "dwc:locationAccordingTo": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/locationAccordingTo",
+      "examples": [
+        "GADM"
+      ]
+    },
+    "dwc:locationRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/locationRemarks",
+      "examples": [
+        "under water since 2005"
+      ]
+    },
+    "georeference": {
+      "type": "object",
+      "properties": {
+        "dwc:verbatimCoordinates": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimCoordinates",
+          "examples": [
+            "41 05 54S 121 05 34W"
+          ]
+        },
+        "dwc:decimalLatitude": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/decimalLatitude",
+          "examples": [
+            -41.0983423
+          ],
+          "minimum": -180,
+          "maximum": 180
+        },
+        "dwc:verbatimLatitude": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimLatitude",
+          "examples": [
+            "41 05 54.03S"
+          ]
+        },
+        "dwc:decimalLongitude": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/decimalLongitude",
+          "examples": [
+            -121.1761111
+          ],
+          "minimum": -180,
+          "maximum": 180
+        },
+        "dwc:verbatimLongitude": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimLongitude",
+          "examples": [
+            "121d 10' 34\" W"
+          ]
+        },
+        "dwc:verbatimCoordinateSystem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimCoordinateSystem",
+          "examples": [
+            "degrees decimal minutes"
+          ]
+        },
+        "dwc:geodeticDatum": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/geodeticDatum",
+          "examples": [
+            "WGS84"
+          ]
+        },
+        "dwc:coordinateUncertaintyInMeters": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters",
+          "examples": [
+            100
+          ],
+          "minimum": 0
+        },
+        "dwc:coordinatePrecision": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/coordinatePrecision",
+          "examples": [
+            0.01667
+          ]
+        },
+        "dwc:pointRadiusSpatialFit": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/pointRadiusSpatialFit",
+          "examples": [
+            1.5708
+          ]
+        },
+        "dwc:footprintWkt": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/footprintWKT",
+          "examples": [
+            "POLYGON ((10 20, 11 20, 11 21, 10 21, 10 20))"
+          ]
+        },
+        "dwc:footprintSrs": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/footprintSRS",
+          "examples": [
+            "epsg:4326"
+          ]
+        },
+        "dwc:verbatimSRS": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimSRS",
+          "examples": [
+            "NAD27"
+          ]
+        },
+        "dwc:footprintSpatialFit": {
+          "type": "integer",
+          "description": "https://rs.tdwg.org/dwc/terms/footprintSpatialFit",
+          "examples": [
+            1.5708
+          ]
+        },
+        "dwc:georeferencedBy": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferencedBy",
+          "examples": [
+            "Janet Fang"
+          ]
+        },
+        "dwc:georeferencedDate": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferencedDate",
+          "examples": [
+            "1963-03-08T14:07-0600"
+          ]
+        },
+        "dwc:georeferenceProtocol": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferenceProtocol",
+          "examples": [
+            "https://doi.org/10.35035/e09p-h128"
+          ]
+        },
+        "dwc:georeferenceSources": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferenceSources",
+          "examples": [
+            "https://www.geonames.org/"
+          ]
+        },
+        "dwc:georeferenceRemarks": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferenceRemarks",
+          "examples": [
+            "Assumed distance by road (Hwy. 101)"
+          ]
+        },
+        "???:preferredSpatialRepresentation": {
+          "type": "string",
+          "$comment": "Not part of DWC"
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"
+          }
+        }
+      }
+    },
+    "geologicalContext": {
+      "type": "object",
+      "properties": {
+        "dwc:earliestEonOrLowestEonothem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestEonOrLowestEonothem",
+          "examples": [
+            "Phanerozoic"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:latestEonOrHighestEonothem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestEonOrHighestEonothem",
+          "examples": [
+            "Proterozoic"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:earliestEraOrLowestErathem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestEraOrLowestErathem",
+          "examples": [
+            "Cenozoic"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:latestEraOrHighestErathem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestEraOrHighestErathem",
+          "examples": [
+            "Mesozoic"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:earliestPeriodOrLowestSystem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestPeriodOrLowestSystem",
+          "examples": [
+            "Tertiary"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:latestPeriodOrHighestSystem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestPeriodOrHighestSystem",
+          "examples": [
+            "Quaternary"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:earliestEpochOrLowestSeries": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestEpochOrLowestSeries",
+          "examples": [
+            "Holocene"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:latestEpochOrHighestSeries": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestEpochOrHighestSeries",
+          "examples": [
+            "Pleistocene"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:earliestAgeOrLowestStage": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestAgeOrLowestStage",
+          "examples": [
+            "Atlantic"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:latestAgeOrHighestStage": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestAgeOrHighestStage",
+          "examples": [
+            "Boreal"
+          ],
+          "$comment": "Strange field, mixes geologic and stratigraphic unit. The earliest/latest is not in line with the rest"
+        },
+        "dwc:lowestBiostratigraphicZone": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/lowestBiostratigraphicZone",
+          "examples": [
+            "Maastrichtian"
+          ],
+          "$comment": "Strange field, lowest and highest"
+        },
+        "dwc:highestBiostratigraphicZone": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/highestBiostratigraphicZone",
+          "examples": [
+            "Blancan"
+          ],
+          "$comment": "Strange field, lowest and highest"
+        },
+        "dwc:lithostratigraphicTerms": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/lithostratigraphicTerms",
+          "examples": [
+            "Pleistocene-Weichselien"
+          ]
+        },
+        "dwc:group": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/group",
+          "examples": [
+            "Bathurst"
+          ]
+        },
+        "dwc:formation": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/formation",
+          "examples": [
+            "House Limestone"
+          ]
+        },
+        "dwc:member": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/member",
+          "examples": [
+            "Lava Dam Member"
+          ]
+        },
+        "dwc:bed": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/bed",
+          "examples": [
+            "Harlem coal"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/material-entity.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/material-entity.json
@@ -88,43 +88,43 @@
         "ILL: Union Co. Wolf Lake by Powder Plant Bridge. 1 March 1975 Coll. S. Ketzler, S. Herbert\n\nMonotoma longicollis 4 ♂ Det TC McElrath 2018\n\nINHS Insect Collection 456782"
       ]
     },
-    "identifications": {
+    "dwc:Identification": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/identifications.json"
       }
     },
-    "assertions": {
+    "???:Assertion": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/assertions.json"
       }
     },
-    "entityRelationships": {
+    "???:EntityRelationship": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/entity-relationships.json"
       }
     },
-    "citations": {
+    "???:Citation": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/citations.json"
       }
     },
-    "identifiers": {
+    "???:Identifier": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/identifiers.json"
       }
     },
-    "events": {
+    "dwc:Event": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/events.json"
       }
     },
-    "agents": {
+    "???:Agent": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/material-entity.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/material-entity.json
@@ -1,0 +1,134 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/material-entity.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment":"DigitalObject Version 0.2.0",
+  "type": "object",
+  "$comment": "Only if the part did not get a separate catalogue number, otherwise it will be a separate digital specimen itself",
+  "properties": {
+    "materialEntityId": {
+      "type": "string"
+    },
+    "dwc:preparations": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/preparations",
+      "example": [
+        "fossil"
+      ]
+    },
+    "dwc:disposition": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/disposition",
+      "examples": [
+        "in collection"
+      ]
+    },
+    "dwc:institutionCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/institutionCode",
+      "examples": [
+        "MNF"
+      ]
+    },
+    "???:institutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier, based on https://rs.tdwg.org/dwc/terms/institutionID",
+      "examples": [
+        "https://ror.org/015hz7p22"
+      ]
+    },
+    "dwc:institutionName": {
+      "type": "string",
+      "description": "Full museum name according to ROR or Wikidata",
+      "examples": [
+        "National Museum of Natural History"
+      ],
+      "$comment": "Not part of DWC or the GBIF UM"
+    },
+    "dwc:collectionCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/collectionCode",
+      "examples": [
+        "EBIRD"
+      ]
+    },
+    "dwc:collectionId": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/collectionID",
+      "examples": [
+        "https://www.gbif.org/grscicoll/collection/fbd3ed74-5a21-4e01-b86a-33d36f032d9c"
+      ],
+      "$comment": "Are we going to use GRSciColl or Cetaf collection identifiers?"
+    },
+    "dwc:ownerInstitutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier for the owning institution",
+      "$comment": "DWC only has ownerInstitutionCode, however code is not an (resolvable identifier)",
+      "examples": [
+        "https://ror.org/03wkt5x30"
+      ]
+    },
+    "dwc:recordedBy": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedBy",
+      "examples": [
+        "José E. Crespo"
+      ]
+    },
+    "dwc:recordedById": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedByID",
+      "examples": [
+        "https://orcid.org/0000-0002-1825-0097"
+      ]
+    },
+    "dwc:verbatimLabel": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimLabel",
+      "examples": [
+        "ILL: Union Co. Wolf Lake by Powder Plant Bridge. 1 March 1975 Coll. S. Ketzler, S. Herbert\n\nMonotoma longicollis 4 ♂ Det TC McElrath 2018\n\nINHS Insect Collection 456782"
+      ]
+    },
+    "identifications": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/identifications.json"
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/assertions.json"
+      }
+    },
+    "entityRelationships": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/entity-relationships.json"
+      }
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/citations.json"
+      }
+    },
+    "identifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/identifiers.json"
+      }
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/events.json"
+      }
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"
+      }
+    }
+  }
+}

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/occurrences.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/occurrences.json
@@ -118,20 +118,6 @@
         "found dead on road"
       ]
     },
-    "dwc:recordedBy": {
-      "type": "string",
-      "description": "https://rs.tdwg.org/dwc/terms/recordedBy",
-      "examples": [
-        "José E. Crespo"
-      ]
-    },
-    "dwc:recordedById": {
-      "description": "https://rs.tdwg.org/dwc/terms/recordedByID",
-      "type": "string",
-      "examples": [
-        "https://orcid.org/0000-0002-1825-0097"
-      ]
-    },
     "???:eventName": {
       "type": "string",
       "comment": "Not sure what this field means"
@@ -198,9 +184,12 @@
       ],
       "$comment": "Is this necessary for specimens"
     },
-    "???:protocolDescription": {
+    "eco:protocolDescriptions": {
       "type": "string",
-      "comment": "Not sure what this field means"
+      "description": "https://rs.tdwg.org/eco/terms/protocolDescriptions",
+      "examples": [
+        "Three conventional harp traps (3.2m ht x 2.2m w) were established in flight path zones for a period of 4 hrs at dawn and dusk for a total of 10 trap nights. Traps were visited on an hourly basis during each deployment period and the trap catch recorded for species, size, weight, sex, age and maternal status."
+      ]
     },
     "dwc:sampleSizeValue": {
       "type": "string",
@@ -249,13 +238,13 @@
       "type": "string",
       "$comment": "Not part of DWC or the UM?"
     },
-    "assertions": {
+    "???:Assertion": {
       "type": "array",
       "items": {
         "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/assertions.json"
       }
     },
-    "location": {
+    "dcterms:Location": {
       "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/location.json"
     }
   }

--- a/data-model/digitalobjects/0.2.0/digital-specimens/schema/occurrences.json
+++ b/data-model/digitalobjects/0.2.0/digital-specimens/schema/occurrences.json
@@ -1,0 +1,262 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/occurrences.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment":"DigitalObject Version 0.2.0",
+  "type": "object",
+  "properties": {
+    "dwc:organismQuantity": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/organismQuantity",
+      "examples": [
+        "27"
+      ]
+    },
+    "dwc:organismQuantityType": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/organismQuantityType",
+      "examples": [
+        "individuals"
+      ],
+      "$comment": "Could this become a enum?"
+    },
+    "dwc:sex": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/sex",
+      "examples": [
+        "female"
+      ],
+      "$comment": "Could this become a enum?"
+    },
+    "dwc:lifeStage": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/lifeStage",
+      "examples": [
+        "adult"
+      ],
+      "$comment": "Could this become a enum?"
+    },
+    "dwc:reproductiveCondition": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/reproductiveCondition",
+      "examples": [
+        "pregnant"
+      ],
+      "$comment": "Could this become a enum?"
+    },
+    "dwc:behavior": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/behavior",
+      "examples": [
+        "running"
+      ],
+      "$comment": "Is this needed for specimen data?"
+    },
+    "dwc:caste": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/caste",
+      "examples": [
+        "queen",
+        "ergatoid"
+      ]
+    },
+    "dwc:vitality": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/vitality",
+      "examples": [
+        "alive",
+        "dead"
+      ],
+      "$comment": "Is this needed for specimen data?"
+    },
+    "dwc:establishmentMeans": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/establishmentMeans",
+      "examples": [
+        "introduced"
+      ],
+      "$comment": "Could be an enumeration based on https://rs.tdwg.org/dwc/doc/em/"
+    },
+    "dwc:occurrenceStatus": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/occurrenceStatus",
+      "examples": [
+        "present"
+      ],
+      "enum": [
+        "present",
+        "absent"
+      ]
+    },
+    "dwc:pathway": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/pathway",
+      "examples": [
+        "releasedForUse"
+      ],
+      "$comment": "Could be an enumeration based on https://rs.tdwg.org/dwc/doc/pw/"
+    },
+    "dwc:degreeOfEstablishment": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/degreeOfEstablishment",
+      "examples": [
+        "captive"
+      ],
+      "$comment": "Could be an enumeration based on https://rs.tdwg.org/dwc/doc/doe/"
+    },
+    "dwc:georeferenceVerificationStatus": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/georeferenceVerificationStatus",
+      "examples": [
+        "verified by data custodian"
+      ],
+      "$comment": "Could be an enumeration based on https://rs.tdwg.org/dwc/doc/em/"
+    },
+    "dwc:occurrenceRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/occurrenceRemarks",
+      "examples": [
+        "found dead on road"
+      ]
+    },
+    "dwc:recordedBy": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedBy",
+      "examples": [
+        "José E. Crespo"
+      ]
+    },
+    "dwc:recordedById": {
+      "description": "https://rs.tdwg.org/dwc/terms/recordedByID",
+      "type": "string",
+      "examples": [
+        "https://orcid.org/0000-0002-1825-0097"
+      ]
+    },
+    "???:eventName": {
+      "type": "string",
+      "comment": "Not sure what this field means"
+    },
+    "dwc:fieldNumber": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/fieldNumber",
+      "examples": [
+        "RV Sol 87-03-08"
+      ]
+    },
+    "dwc:recordNumber": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordNumber",
+      "examples": [
+        "OPP 7101"
+      ]
+    },
+    "dwc:eventDate": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/eventDate",
+      "examples": [
+        "1963-03-08T14:07-0600"
+      ]
+    },
+    "dwc:verbatimEventDate": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimEventDate",
+      "examples": [
+        "Marzo 2002"
+      ]
+    },
+    "dwc:year": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/year",
+      "maximum": 9999,
+      "examples": [
+        2008
+      ]
+    },
+    "dwc:month": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/month",
+      "maximum": 12,
+      "minimum": 1,
+      "examples": [
+        12
+      ]
+    },
+    "dwc:day": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/day",
+      "maximum": 31,
+      "minimum": 1,
+      "examples": [
+        29
+      ]
+    },
+    "dwc:habitat": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/habitat",
+      "examples": [
+        "savanna"
+      ],
+      "$comment": "Is this necessary for specimens"
+    },
+    "???:protocolDescription": {
+      "type": "string",
+      "comment": "Not sure what this field means"
+    },
+    "dwc:sampleSizeValue": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/sampleSizeValue",
+      "examples": [
+        "5"
+      ]
+    },
+    "dwc:sampleSizeUnit": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/sampleSizeUnit",
+      "examples": [
+        "meters"
+      ]
+    },
+    "dwc:samplingProtocol": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/samplingProtocol",
+      "examples": [
+        "collected directly from the wild"
+      ]
+    },
+    "???:eventEffort": {
+      "type": "string",
+      "comment": "Not sure what this field means"
+    },
+    "dwc:fieldNotes": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/fieldNotes",
+      "examples": [
+        "Notes available in the Grinnell-Miller Library"
+      ]
+    },
+    "dwc:eventRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/eventRemarks",
+      "examples": [
+        "After the recent rains the river is nearly at flood stage"
+      ]
+    },
+    "???:collectorName": {
+      "type": "string",
+      "$comment": "Not part of DWC or the UM?"
+    },
+    "???:collectorId": {
+      "type": "string",
+      "$comment": "Not part of DWC or the UM?"
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/assertions.json"
+      }
+    },
+    "location": {
+      "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/location.json"
+    }
+  }
+}


### PR DESCRIPTION
PR with a bunch of new fields.
Most are verbatim fields, which we now added to the datamodel.
We also added a couple of ID fields which weren't previously included.

We try to make this a new minor version upgrade of the 0 version, let's see how that works out.

