### PR TITLE
Web batch annotations

### DIFF
--- a/data-model/annotations/0.1.0/examples/example-annotation-event-for-web.json
+++ b/data-model/annotations/0.1.0/examples/example-annotation-event-for-web.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "type": "annotation",
+    "attributes": {
+      "annotations": [
+        {
+          "oa:motivation": "oa:commenting",
+          "oa:target": {
+            "ods:id": "https://hdl.handle.net/20.500.125/1111111",
+            "ods:type": "https://doi.org/21.T11148/894b1e6cad57e921764e",
+            "oa:selector": {
+              "ods:type": "ClassSelector",
+              "oa:class": "specimenName"
+            }
+          },
+          "oa:body": {
+            "ods:type": "body",
+            "oa:value": [],
+            "dcterms:reference": "reference",
+            "ods:score": 0.9
+          }
+        }
+      ],
+      "batchMetadata": [
+        {
+          "searchParams": [
+            {
+              "inputField": "field",
+              "inputValue": "value"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/data-model/annotations/0.1.0/schema/annotation-event-for-web.json
+++ b/data-model/annotations/0.1.0/schema/annotation-event-for-web.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.dissco.tech/schemas/annotations/0.1.0/annotation-event-for-web.json",
+  "description": "Web batch annotation. For DiSSCo internal use only.",
+  "$comment": "Fewer fields are required in this schema because these requests are sent to the backend for processing.",
+  "properties": {
+    "annotation": {
+      "type": "object",
+      "properties": {
+        "ods:id": {
+          "type": "string"
+        },
+        "rdf:type": {
+          "const": "Annotation"
+        },
+        "oa:motivation": {
+          "enum": [
+            "ods:adding",
+            "oa:assessing",
+            "oa:editing",
+            "oa:commenting"
+          ]
+        },
+        "oa:motivatedBy": {
+          "type": "string"
+        },
+        "oa:target": {
+          "type": "object",
+          "properties": {
+            "ods:id": {
+              "type": "string"
+            },
+            "ods:type": {
+              "type": "string"
+            },
+            "oa:selector": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "ods:type": {
+                      "const": "FieldSelector"
+                    },
+                    "ods:field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ods:type",
+                    "ods:field"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ods:type": {
+                      "const": "ClassSelector"
+                    },
+                    "oa:class": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ods:type",
+                    "oa:class"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ods:type": {
+                      "const": "FragmentSelector"
+                    },
+                    "ac:hasRoi": {
+                      "type": "object",
+                      "properties": {
+                        "ac:xFrac": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "ac:yFrac": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "ac:widthFrac": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "ac:heightFrac": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        }
+                      },
+                      "required": [
+                        "ac:xFrac",
+                        "ac:yFrac",
+                        "ac:widthFrac",
+                        "ac:heightFrac"
+                      ]
+                    },
+                    "dcterms:conformsTo": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ods:type",
+                    "ac:hasRoi"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "ods:id",
+            "ods:type"
+          ]
+        },
+        "oa:body": {
+          "type": "object",
+          "properties": {
+            "ods:type": {
+              "type": "string"
+            },
+            "oa:value": {
+              "type": "array"
+            },
+            "dcterms:reference": {
+              "type": "string"
+            },
+            "ods:score": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "required": [
+            "ods:type",
+            "oa:value"
+          ]
+        }
+      },
+      "required": [
+        "rdf:type",
+        "oa:motivation",
+        "oa:target",
+        "oa:body"
+      ]
+    },
+    "batchMetadata": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/fdo-types/0.1.0/annotation-batch-metadata.json"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "annotation",
+    "batchMetadata"
+  ]
+}

--- a/data-model/annotations/0.1.0/schema/annotation-event-for-web.json
+++ b/data-model/annotations/0.1.0/schema/annotation-event-for-web.json
@@ -4,163 +4,186 @@
   "description": "Web batch annotation. For DiSSCo internal use only.",
   "$comment": "Fewer fields are required in this schema because these requests are sent to the backend for processing.",
   "properties": {
-    "annotation": {
+    "data": {
       "type": "object",
       "properties": {
-        "ods:id": {
-          "type": "string"
+        "type": {
+          "const": "annotation"
         },
-        "rdf:type": {
-          "const": "Annotation"
-        },
-        "oa:motivation": {
-          "enum": [
-            "ods:adding",
-            "oa:assessing",
-            "oa:editing",
-            "oa:commenting"
-          ]
-        },
-        "oa:motivatedBy": {
-          "type": "string"
-        },
-        "oa:target": {
+        "attributes": {
           "type": "object",
           "properties": {
-            "ods:id": {
-              "type": "string"
-            },
-            "ods:type": {
-              "type": "string"
-            },
-            "oa:selector": {
-              "type": "object",
-              "oneOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "ods:type": {
-                      "const": "FieldSelector"
-                    },
-                    "ods:field": {
-                      "type": "string"
-                    }
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ods:id": {
+                    "type": "string"
                   },
-                  "required": [
-                    "ods:type",
-                    "ods:field"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "ods:type": {
-                      "const": "ClassSelector"
-                    },
-                    "oa:class": {
-                      "type": "string"
-                    }
+                  "rdf:type": {
+                    "const": "Annotation"
                   },
-                  "required": [
-                    "ods:type",
-                    "oa:class"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "ods:type": {
-                      "const": "FragmentSelector"
-                    },
-                    "ac:hasRoi": {
-                      "type": "object",
-                      "properties": {
-                        "ac:xFrac": {
-                          "type": "number",
-                          "minimum": 0,
-                          "maximum": 1
-                        },
-                        "ac:yFrac": {
-                          "type": "number",
-                          "minimum": 0,
-                          "maximum": 1
-                        },
-                        "ac:widthFrac": {
-                          "type": "number",
-                          "minimum": 0,
-                          "maximum": 1
-                        },
-                        "ac:heightFrac": {
-                          "type": "number",
-                          "minimum": 0,
-                          "maximum": 1
-                        }
+                  "oa:motivation": {
+                    "enum": [
+                      "ods:adding",
+                      "oa:assessing",
+                      "oa:editing",
+                      "oa:commenting"
+                    ]
+                  },
+                  "oa:motivatedBy": {
+                    "type": "string"
+                  },
+                  "oa:target": {
+                    "type": "object",
+                    "properties": {
+                      "ods:id": {
+                        "type": "string"
                       },
-                      "required": [
-                        "ac:xFrac",
-                        "ac:yFrac",
-                        "ac:widthFrac",
-                        "ac:heightFrac"
-                      ]
+                      "ods:type": {
+                        "type": "string"
+                      },
+                      "oa:selector": {
+                        "type": "object",
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "ods:type": {
+                                "const": "FieldSelector"
+                              },
+                              "ods:field": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "ods:type",
+                              "ods:field"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "ods:type": {
+                                "const": "ClassSelector"
+                              },
+                              "oa:class": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "ods:type",
+                              "oa:class"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "ods:type": {
+                                "const": "FragmentSelector"
+                              },
+                              "ac:hasRoi": {
+                                "type": "object",
+                                "properties": {
+                                  "ac:xFrac": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                  },
+                                  "ac:yFrac": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                  },
+                                  "ac:widthFrac": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                  },
+                                  "ac:heightFrac": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                  }
+                                },
+                                "required": [
+                                  "ac:xFrac",
+                                  "ac:yFrac",
+                                  "ac:widthFrac",
+                                  "ac:heightFrac"
+                                ]
+                              },
+                              "dcterms:conformsTo": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "ods:type",
+                              "ac:hasRoi"
+                            ]
+                          }
+                        ]
+                      }
                     },
-                    "dcterms:conformsTo": {
-                      "type": "string"
-                    }
+                    "required": [
+                      "ods:id",
+                      "ods:type"
+                    ]
                   },
-                  "required": [
-                    "ods:type",
-                    "ac:hasRoi"
-                  ]
-                }
-              ]
+                  "oa:body": {
+                    "type": "object",
+                    "properties": {
+                      "ods:type": {
+                        "type": "string"
+                      },
+                      "oa:value": {
+                        "type": "array"
+                      },
+                      "dcterms:reference": {
+                        "type": "string"
+                      },
+                      "ods:score": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      }
+                    },
+                    "required": [
+                      "ods:type",
+                      "oa:value"
+                    ]
+                  }
+                },
+                "required": [
+                  "oa:motivation",
+                  "oa:target",
+                  "oa:body"
+                ]
+              },
+              "minItems": 1,
+              "maxItems": 1
+            },
+            "batchMetadata": {
+              "type": "array",
+              "items": {
+                "$ref": "https://schemas.dissco.tech/schemas/fdo-types/0.1.0/annotation-batch-metadata.json"
+              },
+              "minItems": 1,
+              "maxItems": 1
             }
           },
           "required": [
-            "ods:id",
-            "ods:type"
-          ]
-        },
-        "oa:body": {
-          "type": "object",
-          "properties": {
-            "ods:type": {
-              "type": "string"
-            },
-            "oa:value": {
-              "type": "array"
-            },
-            "dcterms:reference": {
-              "type": "string"
-            },
-            "ods:score": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 1
-            }
-          },
-          "required": [
-            "ods:type",
-            "oa:value"
+            "annotations",
+            "batchMetadata"
           ]
         }
       },
       "required": [
-        "rdf:type",
-        "oa:motivation",
-        "oa:target",
-        "oa:body"
+        "type",
+        "attributes"
       ]
-    },
-    "batchMetadata": {
-      "type": "array",
-      "items": {
-        "$ref": "https://schemas.dissco.tech/schemas/fdo-types/0.1.0/annotation-batch-metadata.json"
-      },
-      "minItems": 1
     }
-  },
-  "required": [
-    "annotation",
-    "batchMetadata"
-  ]
+  }
+
 }

--- a/data-model/annotations/0.1.0/schema/annotation-event.json
+++ b/data-model/annotations/0.1.0/schema/annotation-event.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.dissco.tech/schemas/annotations/0.1.0/annotation-event.json",
-  "description": "Object sent to annotation processing service",
+  "description": "Object sent to annotation processing service from core backend. Internal use only.",
   "properties": {
     "annotations": {
       "type": "array",
@@ -16,19 +16,9 @@
     "batchMetadata": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "placeInBatch": {
-            "type": "integer"
-          },
-          "inputField": {
-            "type": "string"
-          },
-          "inputValue": {
-            "type": "string"
-          }
-        }
-      }
+        "$ref": "https://schemas.dissco.tech/schemas/fdo-types/0.1.0/annotation-batch-metadata.json"
+      },
+      "minItems": 1
     },
     "required": [
       "annotations",

--- a/data-model/annotations/0.1.0/schema/batch-metadata.json
+++ b/data-model/annotations/0.1.0/schema/batch-metadata.json
@@ -12,11 +12,17 @@
         "properties": {
           "inputField": {
             "type": "string",
-            "description": "JsonPath (mixed notation) of field used to base annotation reasoning on"
+            "description": "JsonPath (mixed notation) of field used to base annotation reasoning on. Indexes must be wildcards",
+            "examples": [
+              "digitalSpecimenWrapper.occurrences[*].location.dwc:country"
+            ]
           },
           "inputValue": {
             "type": "string",
-            "description": "Value stored at the field indicated in inputField "
+            "description": "Value stored at the field indicated in inputField",
+            "examples": [
+              "Netherlands"
+            ]
           }
         },
         "required": [

--- a/data-model/annotations/0.1.0/schema/batch-metadata.json
+++ b/data-model/annotations/0.1.0/schema/batch-metadata.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.dissco.tech/schemas/fdo-types/0.1.0/annotation-batch-metadata.json",
+  "properties": {
+    "placeInBatch": {
+      "type": "integer"
+    },
+    "searchParams": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "inputField": {
+            "type": "string",
+            "description": "JsonPath (mixed notation) of field used to base annotation reasoning on"
+          },
+          "inputValue": {
+            "type": "string",
+            "description": "Value stored at the field indicated in inputField "
+          }
+        },
+        "required": [
+          "inputField",
+          "inputValue"
+        ]
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "placeInBatch",
+    "searchParams"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Schemas for batching web annotations

To batch request batch annotations through DiSSCover, front end sends an AnnotationEvent, which includes the annotation and batch metadata, adhering to the `annotation-event-for-web` schema. The contents of the annotation are not different from the non-batched annotations, but they are in an array. What's different is that we now require BatchMetadata, which contains search parameters for the batching functionality downstream. 

`Annotations` and `BatchMetadata` need to be a list containing exactly one item per field.

"place in Batch" is a constant set in the backend. tom, you only need to worry about the search parameters 