### PR TITLE
Version 0.3.0 for specimen and media

### DIFF
--- a/data-model/Dockerfile
+++ b/data-model/Dockerfile
@@ -29,3 +29,7 @@ COPY ./fdo-types/0.1.0/source-systems/schema schema-root/schemas/fdo-types/0.1.0
 COPY ./fdo-types/0.1.0/virtual-collections/schema schema-root/schemas/fdo-types/0.1.0/vitual-collections
 
 COPY ./fdo-types/0.2.0/digital-specimens/schema schema-root/schemas/digitalobjects/0.2.0/digital-specimens
+
+COPY ./fdo-types/0.3.0/digital-specimens/schema schema-root/schemas/fdo-types/0.3.0/digital-specimens
+COPY ./fdo-types/0.3.0/shared-models/schema schema-root/schemas/fdo-types/0.3.0/shared-models
+COPY ./fdo-types/0.3.0/digital-media-objects/schema schema-root/schemas/fdo-types/0.3.0/digital-media-objects

--- a/data-model/fdo-types/0.3.0/RELEASE_NOTES.md
+++ b/data-model/fdo-types/0.3.0/RELEASE_NOTES.md
@@ -1,0 +1,16 @@
+# Release Notes
+
+New version 0.3.0 for all files concerning the digital specimen.
+
+## ODS Prefix
+ODS prefix for all terms which still weren't assigned to a ontology.
+
+## Updated arrays to be plural
+We decided to update the arrays to be plural, in line with recommendated practices.
+This means that where Darwin Core Classes where available we wrapped this by an ods term with the plural.
+For example, `dwc:Identification` becomes wrapped in `ods:Identifications` which now contains zero or more instances of `dwc:Identification`.
+The tradeoff is that we added an additional layer of nesting, but we believe this is worth it to keep the terms in line with the Darwin Core standard.
+
+## Other
+Small changes in description for some terms.
+dwc:institutionName is not a Darwin Core term, converted to ods:institutionName. 

--- a/data-model/fdo-types/0.3.0/digital-media-objects/schema/digital-entity.json
+++ b/data-model/fdo-types/0.3.0/digital-media-objects/schema/digital-entity.json
@@ -1,0 +1,195 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/fdo-types/0.3.0/digital-media-objects/digital-entity.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "DigitalObject Version 0.3.0",
+  "type": "object",
+  "properties": {
+    "ods:id": {
+      "type": "string",
+      "description": "The unique digital identifier of the object",
+      "pattern": "https:\/\/hdl.handle.net\/20.5000.1025\/(.){3}-(.){3}-(.){3}",
+      "examples": [
+        "https://hdl.handle.net.org/20.5000.1025/XXX-XXX-XXX"
+      ],
+      "$comment": "Does an image get a DOI or a handle?"
+    },
+    "ods:version": {
+      "type": "integer",
+      "description": "The version of the object, each change generates a new version",
+      "minimum": 0,
+      "examples": [
+        1
+      ]
+    },
+    "ods:created": {
+      "type": "string",
+      "description": "The timestamp that the object version was created in DiSSCo",
+      "format": "date-time",
+      "examples": [
+      ]
+    },
+    "ods:type": {
+      "type": "string",
+      "description": "The FDO type of the object",
+      "$comment": "Unclear what value goes here"
+    },
+    "dcterms:type": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/type",
+      "enum": [
+        "Collection",
+        "Dataset",
+        "Event",
+        "Image",
+        "InteractiveResource",
+        "MovingImage",
+        "PhysicalObject",
+        "Service",
+        "Software",
+        "Sound",
+        "StillImage",
+        "Text"
+      ]
+    },
+    "ac:accessUri": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/ac/terms/accessURI",
+      "examples": [
+      ]
+    },
+    "dwc:institutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier, based on https://rs.tdwg.org/dwc/terms/institutionID",
+      "examples": [
+        "https://ror.org/015hz7p22"
+      ],
+      "$comment": "Add format for ROR or Wikidata ID"
+    },
+    "ods:institutionName": {
+      "type": "string",
+      "description": "Full museum name according to ROR or Wikidata",
+      "examples": [
+        "National Museum of Natural History"
+      ],
+      "$comment": "Not part of DWC or the GBIF UM"
+    },
+    "xmpRights:webStatement": {
+      "type": "string",
+      "description": "https://ns.adobe.com/xap/1.0/rights/WebStatement",
+      "$comment": "What is the difference with dcterms:license?"
+    },
+    "dcterms:format": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/format",
+      "$comment": "Create a enum for this?"
+    },
+    "dcterms:license": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/license",
+      "$comment": "Create a enum for this?"
+    },
+    "dcterms:description": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/description"
+    },
+    "dcterms:rights": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/rights",
+      "$comment": "What is the difference with dcterms:license?"
+    },
+    "ods:rightsUri": {
+      "type": "string",
+      "format": "uri",
+      "$comment": "What is the difference with dcterms:license? or dcterms:rights?. dcterms:rights is already recommended to be a URI"
+    },
+    "dcterms:accessRights": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/accessRights",
+      "$comment": "What is the difference with dcterms:license?"
+    },
+    "dcterms:rightsHolder": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/rightsHolder",
+      "examples": [
+      ]
+    },
+    "dcterms:source": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/source"
+    },
+    "ods:sourceUri": {
+      "type": "string",
+      "format": "uri",
+      "$comment": "It is already recommended to use URI in the dcterms:source"
+    },
+    "dcterms:creator": {
+      "type": "string",
+      "description": "https://purl.org/dc/elements/1.1/creator"
+    },
+    "dcterms:created": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/created"
+    },
+    "dcterms:modified": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/modified"
+    },
+    "ods:Assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Assertion": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/assertions.json"
+        }
+      }
+    },
+    "ods:Citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Citation": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/citations.json"
+        }
+      }
+    },
+    "ods:Identifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Identifier": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/identifiers.json"
+        }
+      }
+    },
+    "ods:EntityRelationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:EntityRelationship": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/entity-relationships.json"
+        }
+      }
+    },
+    "ods:Agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Agent": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"
+        }
+      }
+    }
+  },
+  "required": [
+    "ods:id",
+    "ods:version",
+    "ods:created",
+    "ac:accessUri",
+    "dcterms:license"
+  ]
+}

--- a/data-model/fdo-types/0.3.0/digital-specimen/schema/chronometric-age.json
+++ b/data-model/fdo-types/0.3.0/digital-specimen/schema/chronometric-age.json
@@ -1,0 +1,125 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/fdo-types/0.3.0/digital-specimens/chronometric-age.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "DigitalObject Version 0.3.0",
+  "type": "object",
+  "properties": {
+    "chrono:verbatimChronometricAge": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/verbatimChronometricAge",
+      "examples": [
+        "27 BC to 14 AD"
+      ]
+    },
+    "ods:verbatimChronometricAgeProtocol": {
+      "type": "string",
+      "$comment": "Unknown term"
+    },
+    "chrono:uncalibratedChronometricAge": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/uncalibratedChronometricAge",
+      "examples": [
+        "1510 +/- 25 14C yr BP"
+      ]
+    },
+    "chrono:chronometricAgeConversionProtocol": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/chronometricAgeConversionProtocol",
+      "examples": [
+        "INTCAL13"
+      ]
+    },
+    "chrono:earliestChronometricAge": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/chrono/terms/earliestChronometricAge",
+      "examples": [
+        100
+      ]
+    },
+    "chrono:earliestChronometricAgeReferenceSystem": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/earliestChronometricAgeReferenceSystem",
+      "examples": [
+        "BP"
+      ]
+    },
+    "chrono:latestChronometricAge": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/chrono/terms/latestChronometricAge",
+      "examples": [
+        12
+      ]
+    },
+    "chrono:latestChronometricAgeReferenceSystem": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/latestChronometricAgeReferenceSystem",
+      "examples": [
+        "BCE"
+      ]
+    },
+    "chrono:chronometricAgeUncertaintyInYears": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/chrono/terms/chronometricAgeUncertaintyInYears",
+      "examples": [
+        100
+      ]
+    },
+    "chrono:chronometricAgeUncertaintyMethod": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/chronometricAgeUncertaintyMethod",
+      "examples": [
+        "Half of 95% confidence interval"
+      ]
+    },
+    "chrono:materialDated": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/materialDated",
+      "examples": [
+        "charred wood"
+      ]
+    },
+    "chrono:materialDatedId": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/materialDatedID",
+      "examples": [
+        "https://doi.org/10.22/XXX-XXX-XXX"
+      ]
+    },
+    "chrono:materialDatedRelationship": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/materialDatedRelationship",
+      "examples": [
+        "sameAs"
+      ]
+    },
+    "chrono:chronometricAgeDeterminedBy": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/chronometricAgeDeterminedBy",
+      "examples": [
+        "Michelle LeFebvre"
+      ]
+    },
+    "chrono:chronometricAgeDeterminedDate": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/chronometricAgeDeterminedDate",
+      "examples": [
+        "2018-11-13T20:20:39+00:00"
+      ]
+    },
+    "chrono:chronometricAgeReferences": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/chronometricAgeReferences",
+      "examples": [
+        "https://doi.org/10.1007/s10814-019-09140-x"
+      ],
+      "$comment": "Or include citation object?"
+    },
+    "chrono:chronometricAgeRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/chrono/terms/chronometricAgeRemarks",
+      "examples": [
+        "Beta Analytic number: 323913"
+      ]
+    }
+  }
+}

--- a/data-model/fdo-types/0.3.0/digital-specimen/schema/digital-specimen.json
+++ b/data-model/fdo-types/0.3.0/digital-specimen/schema/digital-specimen.json
@@ -1,0 +1,372 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/digital-specimen.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "DigitalObject Version 0.3.0",
+  "type": "object",
+  "properties": {
+    "ods:id": {
+      "type": "string",
+      "description": "The unique digital identifier of the object",
+      "pattern": "https:\/\/doi.org\/10.22\/(.){3}-(.){3}-(.){3}",
+      "examples": [
+        "https://doi.org/10.22/XXX-XXX-XXX"
+      ]
+    },
+    "ods:version": {
+      "type": "integer",
+      "description": "The version of the object, each change generates a new version",
+      "minimum": 1,
+      "examples": [
+        1
+      ]
+    },
+    "ods:created": {
+      "type": "string",
+      "description": "The timestamp that the object version was created in DiSSCo",
+      "format": "date-time",
+      "examples": [
+        "2023-10-02T12:31:34.806Z"
+      ]
+    },
+    "ods:type": {
+      "type": "string",
+      "description": "The FDO type of the object",
+      "$comment": "Unclear what value goes here"
+    },
+    "ods:midsLevel": {
+      "type": "integer",
+      "description": "The MIDS level of the object, see https://www.tdwg.org/community/cd/mids/",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "ods:normalisedPhysicalSpecimenId": {
+      "type": "string",
+      "description": "The physical specimen identifier of the object. When locally unique this is a combination between source-system-id and the local identifier"
+    },
+    "ods:physicalSpecimenId": {
+      "type": "string",
+      "description": "The physical specimen identifier of the object. Taken over as-is"
+    },
+    "ods:physicalSpecimenIdType": {
+      "type": "string",
+      "description": "To indicate if the physical identifier is globally unique or locally unique",
+      "enum": [
+        "Resolvable",
+        "Global",
+        "Local"
+      ],
+      "$comment": "Do we need to further distinguish the identifier, for example add 'RESOLVABLE'"
+    },
+    "ods:topicOrigin": {
+      "type": "string",
+      "description": "The topic origin of the specimen",
+      "enum": [
+        "Natural",
+        "Human-made",
+        "Mixed origin",
+        "Unclassified"
+      ],
+      "example": [
+        "Natural"
+      ]
+    },
+    "ods:topicDomain": {
+      "type": "string",
+      "description": "The topic domain of the specimen",
+      "enum": [
+        "Life",
+        "Environment",
+        "Earth System",
+        "Extraterrestrial",
+        "Cultural Artefacts",
+        "Archive Material",
+        "Unclassified"
+      ],
+      "example": [
+        "Life"
+      ]
+    },
+    "ods:topicDiscipline": {
+      "type": "string",
+      "description": "The topic discipline of the specimen",
+      "enum": [
+        "Anthropology",
+        "Botany",
+        "Astrogeology",
+        "Geology",
+        "Microbiology",
+        "Palaeontology",
+        "Zoology",
+        "Ecology",
+        "Other Biodiversity",
+        "Other Geodiversity",
+        "Unclassified"
+      ],
+      "example": [
+        "Botany"
+      ]
+    },
+    "ods:markedAsType": {
+      "type": "boolean",
+      "description": "The specimen is marked as a type specimen"
+    },
+    "ods:hasMedia": {
+      "type": "boolean",
+      "description": "Indicates if there are any media objects attached to this specimen"
+    },
+    "ods:specimenName": {
+      "type": "string",
+      "description": "The accepted specimen name of the digital specimen",
+      "example": [
+        "Roptrocerus typographi (Györfi, 1952)"
+      ]
+    },
+    "ods:sourceSystem": {
+      "type": "string",
+      "description": "The handle to the source system object which retrieved the data from the CMS",
+      "pattern": "https:\/\/hdl.handle.net\/20.5000.1025\/(.){3}-(.){3}-(.){3}"
+    },
+    "ods:livingOrPreserved": {
+      "type": "string",
+      "description": "Whether the specimen is living or preserved",
+      "enum": [
+        "Living",
+        "Preserved"
+      ]
+    },
+    "dcterms:license": {
+      "type": "string",
+      "description": "License for the metadata of the physical specimen",
+      "$comment": "Determine available licenses"
+    },
+    "dcterms:modified": {
+      "type": "string",
+      "description": "Modification date for specimen information"
+    },
+    "dwc:basisOfRecord": {
+      "type": "string",
+      "description": "The basis for the record",
+      "$comment": "Switch to enumeration as this is a limited list"
+    },
+    "dwc:preparations": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/preparations",
+      "example": [
+        "fossil"
+      ]
+    },
+    "dwc:disposition": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/disposition",
+      "examples": [
+        "in collection"
+      ]
+    },
+    "dwc:institutionCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/institutionCode",
+      "examples": [
+        "MNF"
+      ]
+    },
+    "dwc:institutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier, based on https://rs.tdwg.org/dwc/terms/institutionID",
+      "examples": [
+        "https://ror.org/015hz7p22"
+      ],
+      "$comment": "Add format for ROR or Wikidata ID"
+    },
+    "ods:institutionName": {
+      "type": "string",
+      "description": "Full museum name according to ROR or Wikidata",
+      "examples": [
+        "National Museum of Natural History"
+      ],
+      "$comment": "Not part of DWC or the GBIF UM"
+    },
+    "dwc:collectionCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/collectionCode",
+      "examples": [
+        "EBIRD"
+      ],
+      "$comment": "Cetaf collection code?"
+    },
+    "dwc:collectionId": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/collectionID",
+      "examples": [
+        "https://www.gbif.org/grscicoll/collection/fbd3ed74-5a21-4e01-b86a-33d36f032d9c"
+      ],
+      "$comment": "Are we going to use GRSciColl or Cetaf collection identifiers?"
+    },
+    "dwc:informationWithheld": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/informationWithheld",
+      "examples": [
+        "location information not given for endangered species"
+      ],
+      "$comment": "Feels like this field should be true or false and another field should contain the explanation"
+    },
+    "dwc:dataGeneralizations": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/dataGeneralizations",
+      "examples": [
+        "Coordinates generalized from original GPS coordinates to the nearest half degree grid cell."
+      ]
+    },
+    "dwc:ownerInstitutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier for the owning institution",
+      "$comment": "DWC only has ownerInstitutionCode, however code is not an (resolvable identifier)",
+      "examples": [
+        "https://ror.org/03wkt5x30"
+      ]
+    },
+    "dwc:recordedBy": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedBy",
+      "examples": [
+        "José E. Crespo"
+      ]
+    },
+    "dwc:recordedById": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedByID",
+      "examples": [
+        "https://orcid.org/0000-0002-1825-0097"
+      ]
+    },
+    "dwc:datasetName": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/datasetName",
+      "examples": [
+        "Hummingbirds"
+      ]
+    },
+    "dcterms:accessRights": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/accessRights",
+      "examples": [
+        "not-for-profit use only"
+      ]
+    },
+    "dcterms:rightsHolder": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/rightsHolder",
+      "examples": [
+        "Museu de História Natural e da Ciência da Universidade do Porto"
+      ]
+    },
+    "dwc:verbatimLabel": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimLabel",
+      "examples": [
+        "ILL: Union Co. Wolf Lake by Powder Plant Bridge. 1 March 1975 Coll. S. Ketzler, S. Herbert\n\nMonotoma longicollis 4 ♂ Det TC McElrath 2018\n\nINHS Insect Collection 456782"
+      ]
+    },
+    "ods:MaterialEntities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "dwc:MaterialEntity": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/material-entity.json"
+        }
+      }
+    },
+    "ods:Identifications": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "dwc:Identification": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/identifications.json"
+        }
+      }
+    },
+    "ods:Assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Assertion": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/assertions.json"
+        }
+      }
+    },
+    "ods:Occurrences": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "dwc:Occurrence": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/occurrences.json"
+        }
+      }
+    },
+    "ods:EntityRelationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:EntityRelationship": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/entity-relationships.json"
+        }
+      }
+    },
+    "ods:Citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Citation": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/citations.json"
+        }
+      }
+    },
+    "ods:Identifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Identifier": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/identifiers.json"
+        }
+      }
+    },
+    "ods:ChronometricAges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:ChronometricAge": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.2.0/digital-specimens/chronometric-age.json"
+        }
+      }
+    },
+    "ods:Agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Agent": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/agent.json"
+        }
+      }
+    }
+  },
+  "required": [
+    "ods:id",
+    "ods:version",
+    "ods:type",
+    "ods:created",
+    "ods:midsLevel",
+    "ods:physicalSpecimenId",
+    "ods:physicalSpecimenIdType",
+    "ods:sourceSystem",
+    "dcterms:license",
+    "dwc:institutionId"
+  ]
+}

--- a/data-model/fdo-types/0.3.0/digital-specimen/schema/identifications.json
+++ b/data-model/fdo-types/0.3.0/digital-specimen/schema/identifications.json
@@ -1,0 +1,364 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/identifications.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "DigitalObject Version 0.3.0",
+  "type": "object",
+  "properties": {
+    "dwc:identificationID": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identificationID",
+      "examples": [
+        "9992"
+      ]
+    },
+    "ods:identificationType": {
+      "type": "string",
+      "description": "The type of identification"
+    },
+    "ods:taxonFormula": {
+      "type": "string",
+      "description": "The full formula of the taxonomic identification"
+    },
+    "dwc:verbatimIdentification": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimIdentification",
+      "examples": [
+        "Peromyscus sp."
+      ]
+    },
+    "dwc:typeStatus": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/typeStatus",
+      "example": [
+        "holotype"
+      ],
+      "$comment": "Unclear if we can make this an enumeration, which values?"
+    },
+    "dwc:identifiedBy": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identifiedBy",
+      "example": [
+        "James L. Patton"
+      ]
+    },
+    "dwc:identifiedById": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identifiedByID",
+      "example": [
+        "https://orcid.org/0000-0002-1825-0097"
+      ]
+    },
+    "dwc:dateIdentified": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/dateIdentified",
+      "example": [
+        "2009-02-20T08:40Z"
+      ]
+    },
+    "dwc:identificationReferences": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identificationReferences",
+      "example": [
+        "Aves del Noroeste Patagonico. Christie et al. 2004."
+      ],
+      "$comment": "Is this still needed or can we add the citation object here?"
+    },
+    "dwc:identificationVerificationStatus": {
+      "type": "boolean",
+      "description": "If this is the accepted identification, based on https://rs.tdwg.org/dwc/terms/identificationVerificationStatus",
+      "example": [
+        true
+      ]
+    },
+    "dwc:identificationRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identificationRemarks",
+      "examples": [
+        "Distinguished between Anthus correndera and Anthus hellmayri based on the comparative lengths of the uñas."
+      ]
+    },
+    "dwc:identificationQualifier": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/identificationQualifier",
+      "examples": [
+        "cf. var. oxyadenia"
+      ]
+    },
+    "ods:typeDesignationType": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "ods:typeDesignatedBy": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "ods:Citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Citation": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.1.0/shared-models/citations.json"
+        }
+      }
+    },
+    "ods:TaxonIdentifications": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:TaxonIdentification": {
+          "type": "object",
+          "properties": {
+            "dwc:taxonID": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/taxonID",
+              "examples": [
+                "https://www.gbif.org/species/212"
+              ]
+            },
+            "dwc:scientificName": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/scientificName",
+              "examples": [
+                "Roptrocerus typographi (Györfi, 1952)"
+              ]
+            },
+            "dwc:scientificNameId": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/scientificNameID",
+              "examples": [
+                "urn:lsid:ipni.org:names:37829-1:1.3"
+              ]
+            },
+            "ods:scientificNameHtmlLabel": {
+              "type": "string",
+              "description": "A Hyper Text Markup Language (HTML) representation of the scientific name. Includes correct formatting of the name.",
+              "examples": [
+                "<i>Absidia ginsan</i> Komin. et al., 1952"
+              ]
+            },
+            "dwc:scientificNameAuthorship": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/scientificNameAuthorship",
+              "examples": [
+                "(Torr.) J.T. Howell"
+              ]
+            },
+            "dwc:nameAccordingTo": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/nameAccordingTo",
+              "examples": [
+                "Plants of the World Online"
+              ]
+            },
+            "dwc:namePublishedInYear": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/namePublishedInYear",
+              "examples": [
+                "2022"
+              ]
+            },
+            "dwc:taxonRank": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/taxonRank",
+              "examples": [
+                "species"
+              ]
+            },
+            "dwc:verbatimTaxonRank": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/verbatimTaxonRank",
+              "examples": [
+                "Agamospecies"
+              ]
+            },
+            "ods:taxonSource": {
+              "type": "string",
+              "description": "Unclear yet",
+              "$comment": "Unknown what this field should be"
+            },
+            "dwc:taxonRemarks": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/taxonRemarks",
+              "examples": [
+                "this name is a misspelling in common use"
+              ]
+            },
+            "dwc:kingdom": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/kingdom",
+              "examples": [
+                "animalia"
+              ],
+              "$comment": "Could be an enum?"
+            },
+            "dwc:phylum": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/phylum",
+              "examples": [
+                "Chordata"
+              ]
+            },
+            "dwc:class": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/class",
+              "examples": [
+                "Hepaticopsida"
+              ]
+            },
+            "dwc:order": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/order",
+              "examples": [
+                "Carnivora"
+              ]
+            },
+            "dwc:family": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/family",
+              "examples": [
+                "Felidae"
+              ]
+            },
+            "dwc:subfamily": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/subfamily",
+              "examples": [
+                "Orchidoideae"
+              ]
+            },
+            "dwc:genus": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/genus",
+              "examples": [
+                "Puma"
+              ]
+            },
+            "dwc:specificEpithet": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/specificEpithet",
+              "examples": [
+                "concolor"
+              ]
+            },
+            "dwc:taxonomicStatus": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/taxonomicStatus",
+              "$comment": "Might become an enum",
+              "examples": [
+                "accepted"
+              ]
+            },
+            "dwc:nomenclaturalCode": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/nomenclaturalCode",
+              "$comment": "Might become an enum",
+              "examples": [
+                "ICBN"
+              ]
+            },
+            "dwc:vernacularName": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/vernacularName",
+              "examples": [
+                "Meerval | Wels | Catfish | Silure glane | Wels | Waller | Siluro | Malle"
+              ]
+            },
+            "dwc:subgenus": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/subgenus",
+              "examples": [
+                "Strobus"
+              ]
+            },
+            "dwc:acceptedNameUsage": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/acceptedNameUsage",
+              "examples": [
+                "Tamias minimus"
+              ]
+            },
+            "dwc:acceptedNameUsageID": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/acceptedNameUsageID",
+              "examples": [
+                "6W3C4"
+              ]
+            },
+            "dwc:cultivarEpithet": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/cultivarEpithet",
+              "examples": [
+                "King Edward"
+              ]
+            },
+            "dwc:genericName": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/genericName",
+              "examples": [
+                "Felis"
+              ]
+            },
+            "dwc:infragenericEpithet": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/infragenericEpithet",
+              "examples": [
+                "Abacetillus"
+              ]
+            },
+            "dwc:infraspecificEpithet": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/infraspecificEpithet",
+              "examples": [
+                "oxyadenia"
+              ]
+            },
+            "dwc:nomenclaturalStatus": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/nomenclaturalStatus",
+              "examples": [
+                "nom. illeg."
+              ]
+            },
+            "dwc:originalNameUsage": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/originalNameUsage",
+              "examples": [
+                "Pinus abies"
+              ]
+            },
+            "dwc:subtribe": {
+              "type": "string",
+              "description": "http://rs.tdwg.org/dwc/terms/subtribe",
+              "examples": [
+                "Plotinini"
+              ]
+            },
+            "dwc:superfamily": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/superfamily",
+              "examples": [
+                "Cerithioidea"
+              ]
+            },
+            "dwc:tribe": {
+              "type": "string",
+              "description": "https://rs.tdwg.org/dwc/terms/tribe",
+              "examples": [
+                "Arethuseae"
+              ]
+            }
+          },
+          "required": [
+            "dwc:scientificName"
+          ]
+        }
+      }
+    }
+  },
+  "required": [
+    "dwc:identificationVerificationStatus"
+  ]
+}

--- a/data-model/fdo-types/0.3.0/digital-specimen/schema/location.json
+++ b/data-model/fdo-types/0.3.0/digital-specimen/schema/location.json
@@ -1,0 +1,448 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/location.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment":"DigitalObject Version 0.3.0",
+  "type": "object",
+  "properties": {
+    "dwc:locationID": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/locationID",
+      "examples": [
+        "https://opencontext.org/subjects/768A875F-E205-4D0B-DE55-BAB7598D0FD1"
+      ]
+    },
+    "dwc:continent": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/continent",
+      "examples": [
+        "Africa"
+      ]
+    },
+    "dwc:waterBody": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/waterBody",
+      "examples": [
+        "Baltic Sea"
+      ]
+    },
+    "dwc:islandGroup": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/islandGroup",
+      "examples": [
+        "Seychelles"
+      ]
+    },
+    "dwc:island": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/island",
+      "examples": [
+        "Vancouver"
+      ]
+    },
+    "dwc:country": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/country",
+      "examples": [
+        "Colombia"
+      ]
+    },
+    "dwc:countryCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/countryCode",
+      "examples": [
+        "SV"
+      ]
+    },
+    "dwc:stateProvince": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/stateProvince",
+      "examples": [
+        "Montana"
+      ]
+    },
+    "dwc:county": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/county",
+      "examples": [
+        "Los Lagos"
+      ]
+    },
+    "dwc:municipality": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/municipality",
+      "examples": [
+        "Holzminden"
+      ]
+    },
+    "dwc:locality": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/locality",
+      "examples": [
+        "Zeeuws-Vlaanderen, Hulst, Braakman"
+      ]
+    },
+    "dwc:verbatimLocality": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimLocality",
+      "examples": [
+        "25 km NNE Bariloche por R. Nac. 237"
+      ]
+    },
+    "dwc:minimumElevationInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/minimumElevationInMeters",
+      "examples": [
+        -100
+      ]
+    },
+    "dwc:higherGeography": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/higherGeography",
+      "examples": [
+        "Britain and Ireland"
+      ]
+    },
+    "dwc:maximumElevationInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/maximumElevationInMeters",
+      "examples": [
+        205
+      ]
+    },
+    "dwc:verbatimElevation": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimElevation",
+      "examples": [
+        "100 - 200 m"
+      ]
+    },
+    "dwc:minimumDistanceAboveSurfaceInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/minimumDistanceAboveSurfaceInMeters",
+      "examples": [
+        -1,
+        5
+      ]
+    },
+    "dwc:maximumDistanceAboveSurfaceInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/maximumDistanceAboveSurfaceInMeters",
+      "examples": [
+        4.2
+      ]
+    },
+    "dwc:minimumDepthInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/minimumDepthInMeters",
+      "examples": [
+        50
+      ]
+    },
+    "dwc:maximumDepthInMeters": {
+      "type": "number",
+      "description": "https://rs.tdwg.org/dwc/terms/maximumDepthInMeters",
+      "examples": [
+        340
+      ]
+    },
+    "dwc:verbatimDepth": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimDepth",
+      "examples": [
+        "100-200 m"
+      ]
+    },
+    "dwc:verticalDatum": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verticalDatum",
+      "examples": [
+        "EGM84"
+      ]
+    },
+    "dwc:locationAccordingTo": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/locationAccordingTo",
+      "examples": [
+        "GADM"
+      ]
+    },
+    "dwc:locationRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/locationRemarks",
+      "examples": [
+        "under water since 2005"
+      ]
+    },
+    "ods:GeoReference": {
+      "type": "object",
+      "properties": {
+        "dwc:verbatimCoordinates": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimCoordinates",
+          "examples": [
+            "41 05 54S 121 05 34W"
+          ]
+        },
+        "dwc:decimalLatitude": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/decimalLatitude",
+          "examples": [
+            -41.0983423
+          ],
+          "minimum": -180,
+          "maximum": 180
+        },
+        "dwc:verbatimLatitude": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimLatitude",
+          "examples": [
+            "41 05 54.03S"
+          ]
+        },
+        "dwc:decimalLongitude": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/decimalLongitude",
+          "examples": [
+            -121.1761111
+          ],
+          "minimum": -180,
+          "maximum": 180
+        },
+        "dwc:verbatimLongitude": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimLongitude",
+          "examples": [
+            "121d 10' 34\" W"
+          ]
+        },
+        "dwc:verbatimCoordinateSystem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimCoordinateSystem",
+          "examples": [
+            "degrees decimal minutes"
+          ]
+        },
+        "dwc:geodeticDatum": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/geodeticDatum",
+          "examples": [
+            "WGS84"
+          ]
+        },
+        "dwc:coordinateUncertaintyInMeters": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters",
+          "examples": [
+            100
+          ],
+          "minimum": 0
+        },
+        "dwc:coordinatePrecision": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/coordinatePrecision",
+          "examples": [
+            0.01667
+          ]
+        },
+        "dwc:pointRadiusSpatialFit": {
+          "type": "number",
+          "description": "https://rs.tdwg.org/dwc/terms/pointRadiusSpatialFit",
+          "examples": [
+            1.5708
+          ]
+        },
+        "dwc:footprintWkt": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/footprintWKT",
+          "examples": [
+            "POLYGON ((10 20, 11 20, 11 21, 10 21, 10 20))"
+          ]
+        },
+        "dwc:footprintSrs": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/footprintSRS",
+          "examples": [
+            "epsg:4326"
+          ]
+        },
+        "dwc:verbatimSRS": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/verbatimSRS",
+          "examples": [
+            "NAD27"
+          ]
+        },
+        "dwc:footprintSpatialFit": {
+          "type": "integer",
+          "description": "https://rs.tdwg.org/dwc/terms/footprintSpatialFit",
+          "examples": [
+            1.5708
+          ]
+        },
+        "dwc:georeferencedBy": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferencedBy",
+          "examples": [
+            "Janet Fang"
+          ]
+        },
+        "dwc:georeferencedDate": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferencedDate",
+          "examples": [
+            "1963-03-08T14:07-0600"
+          ]
+        },
+        "dwc:georeferenceProtocol": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferenceProtocol",
+          "examples": [
+            "https://doi.org/10.35035/e09p-h128"
+          ]
+        },
+        "dwc:georeferenceSources": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferenceSources",
+          "examples": [
+            "https://www.geonames.org/"
+          ]
+        },
+        "dwc:georeferenceRemarks": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/georeferenceRemarks",
+          "examples": [
+            "Assumed distance by road (Hwy. 101)"
+          ]
+        },
+        "ods:preferredSpatialRepresentation": {
+          "type": "string",
+          "$comment": "Not part of DWC"
+        }
+      }
+    },
+    "dwc:GeologicalContext": {
+      "type": "object",
+      "properties": {
+        "dwc:earliestEonOrLowestEonothem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestEonOrLowestEonothem",
+          "examples": [
+            "Phanerozoic"
+          ]
+        },
+        "dwc:latestEonOrHighestEonothem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestEonOrHighestEonothem",
+          "examples": [
+            "Proterozoic"
+          ]
+        },
+        "dwc:earliestEraOrLowestErathem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestEraOrLowestErathem",
+          "examples": [
+            "Cenozoic"
+          ]
+        },
+        "dwc:latestEraOrHighestErathem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestEraOrHighestErathem",
+          "examples": [
+            "Mesozoic"
+          ]
+        },
+        "dwc:earliestPeriodOrLowestSystem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestPeriodOrLowestSystem",
+          "examples": [
+            "Tertiary"
+          ]
+        },
+        "dwc:latestPeriodOrHighestSystem": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestPeriodOrHighestSystem",
+          "examples": [
+            "Quaternary"
+          ]
+        },
+        "dwc:earliestEpochOrLowestSeries": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestEpochOrLowestSeries",
+          "examples": [
+            "Holocene"
+          ]
+        },
+        "dwc:latestEpochOrHighestSeries": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestEpochOrHighestSeries",
+          "examples": [
+            "Pleistocene"
+          ]
+        },
+        "dwc:earliestAgeOrLowestStage": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/earliestAgeOrLowestStage",
+          "examples": [
+            "Atlantic"
+          ]
+        },
+        "dwc:latestAgeOrHighestStage": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/latestAgeOrHighestStage",
+          "examples": [
+            "Boreal"
+          ]
+        },
+        "dwc:lowestBiostratigraphicZone": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/lowestBiostratigraphicZone",
+          "examples": [
+            "Maastrichtian"
+          ]
+        },
+        "dwc:highestBiostratigraphicZone": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/highestBiostratigraphicZone",
+          "examples": [
+            "Blancan"
+          ]
+        },
+        "dwc:lithostratigraphicTerms": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/lithostratigraphicTerms",
+          "examples": [
+            "Pleistocene-Weichselien"
+          ]
+        },
+        "dwc:group": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/group",
+          "examples": [
+            "Bathurst"
+          ]
+        },
+        "dwc:formation": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/formation",
+          "examples": [
+            "House Limestone"
+          ]
+        },
+        "dwc:member": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/member",
+          "examples": [
+            "Lava Dam Member"
+          ]
+        },
+        "dwc:bed": {
+          "type": "string",
+          "description": "https://rs.tdwg.org/dwc/terms/bed",
+          "examples": [
+            "Harlem coal"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data-model/fdo-types/0.3.0/digital-specimen/schema/material-entity.json
+++ b/data-model/fdo-types/0.3.0/digital-specimen/schema/material-entity.json
@@ -1,0 +1,159 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/material-entity.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "DigitalObject Version 0.3.0",
+  "type": "object",
+  "$comment": "Only if the part did not get a separate catalogue number, otherwise it will be a separate digital specimen itself",
+  "properties": {
+    "ods:materialEntityId": {
+      "type": "string"
+    },
+    "dwc:preparations": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/preparations",
+      "example": [
+        "fossil"
+      ]
+    },
+    "dwc:disposition": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/disposition",
+      "examples": [
+        "in collection"
+      ]
+    },
+    "dwc:institutionCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/institutionCode",
+      "examples": [
+        "MNF"
+      ]
+    },
+    "dwc:institutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier, based on https://rs.tdwg.org/dwc/terms/institutionID",
+      "examples": [
+        "https://ror.org/015hz7p22"
+      ],
+      "$comment": "Add format for ROR or Wikidata ID"
+    },
+    "ods:institutionName": {
+      "type": "string",
+      "description": "Full museum name according to ROR or Wikidata",
+      "examples": [
+        "National Museum of Natural History"
+      ],
+      "$comment": "Not part of DWC or the GBIF UM"
+    },
+    "dwc:collectionCode": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/collectionCode",
+      "examples": [
+        "EBIRD"
+      ]
+    },
+    "dwc:collectionId": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/collectionID",
+      "examples": [
+        "https://www.gbif.org/grscicoll/collection/fbd3ed74-5a21-4e01-b86a-33d36f032d9c"
+      ],
+      "$comment": "Are we going to use GRSciColl or Cetaf collection identifiers?"
+    },
+    "dwc:ownerInstitutionId": {
+      "type": "string",
+      "description": "ROR or Wikidata identifier for the owning institution",
+      "$comment": "DWC only has ownerInstitutionCode, however code is not an (resolvable identifier)",
+      "examples": [
+        "https://ror.org/03wkt5x30"
+      ]
+    },
+    "dwc:recordedBy": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedBy",
+      "examples": [
+        "José E. Crespo"
+      ]
+    },
+    "dwc:recordedById": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordedByID",
+      "examples": [
+        "https://orcid.org/0000-0002-1825-0097"
+      ]
+    },
+    "dwc:verbatimLabel": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimLabel",
+      "examples": [
+        "ILL: Union Co. Wolf Lake by Powder Plant Bridge. 1 March 1975 Coll. S. Ketzler, S. Herbert\n\nMonotoma longicollis 4 ♂ Det TC McElrath 2018\n\nINHS Insect Collection 456782"
+      ]
+    },
+    "dwc:Identification": {
+      "type": "array",
+      "items": {
+        "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/identifications.json"
+      }
+    },
+    "ods:Assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Assertion": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/assertions.json"
+        }
+      }
+    },
+    "ods:EntityRelationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:EntityRelationship": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/entity-relationships.json"
+        }
+      }
+    },
+    "ods:Citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Citation": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/citations.json"
+        }
+      }
+    },
+    "ods:Identifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Identifier": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/identifiers.json"
+        }
+      }
+    },
+    "ods:Events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "dwc:Event": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/events.json"
+        }
+      }
+    },
+    "ods:Agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Agent": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/agent.json"
+        }
+      }
+    }
+  }
+}

--- a/data-model/fdo-types/0.3.0/digital-specimen/schema/occurrences.json
+++ b/data-model/fdo-types/0.3.0/digital-specimen/schema/occurrences.json
@@ -1,0 +1,256 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/occurrences.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment":"DigitalObject Version 0.3.0",
+  "type": "object",
+  "properties": {
+    "dwc:organismQuantity": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/organismQuantity",
+      "examples": [
+        "27"
+      ]
+    },
+    "dwc:organismQuantityType": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/organismQuantityType",
+      "examples": [
+        "individuals"
+      ],
+      "$comment": "Could this become a enum?"
+    },
+    "dwc:sex": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/sex",
+      "examples": [
+        "female"
+      ],
+      "$comment": "Could this become a enum?"
+    },
+    "dwc:lifeStage": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/lifeStage",
+      "examples": [
+        "adult"
+      ],
+      "$comment": "Could this become a enum?"
+    },
+    "dwc:reproductiveCondition": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/reproductiveCondition",
+      "examples": [
+        "pregnant"
+      ],
+      "$comment": "Could this become a enum?"
+    },
+    "dwc:behavior": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/behavior",
+      "examples": [
+        "running"
+      ],
+      "$comment": "Is this needed for specimen data?"
+    },
+    "dwc:caste": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/caste",
+      "examples": [
+        "queen",
+        "ergatoid"
+      ]
+    },
+    "dwc:vitality": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/vitality",
+      "examples": [
+        "alive",
+        "dead"
+      ],
+      "$comment": "Is this needed for specimen data?"
+    },
+    "dwc:establishmentMeans": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/establishmentMeans",
+      "examples": [
+        "introduced"
+      ],
+      "$comment": "Could be an enumeration based on https://rs.tdwg.org/dwc/doc/em/"
+    },
+    "dwc:occurrenceStatus": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/occurrenceStatus",
+      "examples": [
+        "present"
+      ],
+      "enum": [
+        "present",
+        "absent"
+      ]
+    },
+    "dwc:pathway": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/pathway",
+      "examples": [
+        "releasedForUse"
+      ],
+      "$comment": "Could be an enumeration based on https://rs.tdwg.org/dwc/doc/pw/"
+    },
+    "dwc:degreeOfEstablishment": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/degreeOfEstablishment",
+      "examples": [
+        "captive"
+      ],
+      "$comment": "Could be an enumeration based on https://rs.tdwg.org/dwc/doc/doe/"
+    },
+    "dwc:georeferenceVerificationStatus": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/georeferenceVerificationStatus",
+      "examples": [
+        "verified by data custodian"
+      ],
+      "$comment": "Could be an enumeration based on https://rs.tdwg.org/dwc/doc/em/"
+    },
+    "dwc:occurrenceRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/occurrenceRemarks",
+      "examples": [
+        "found dead on road"
+      ]
+    },
+    "ods:eventName": {
+      "type": "string",
+      "description": "The name of the event"
+    },
+    "dwc:fieldNumber": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/fieldNumber",
+      "examples": [
+        "RV Sol 87-03-08"
+      ]
+    },
+    "dwc:recordNumber": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/recordNumber",
+      "examples": [
+        "OPP 7101"
+      ]
+    },
+    "dwc:eventDate": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/eventDate",
+      "examples": [
+        "1963-03-08T14:07-0600"
+      ]
+    },
+    "dwc:verbatimEventDate": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/verbatimEventDate",
+      "examples": [
+        "Marzo 2002"
+      ]
+    },
+    "dwc:year": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/year",
+      "maximum": 9999,
+      "examples": [
+        2008
+      ]
+    },
+    "dwc:month": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/month",
+      "maximum": 12,
+      "minimum": 1,
+      "examples": [
+        12
+      ]
+    },
+    "dwc:day": {
+      "type": "integer",
+      "description": "https://rs.tdwg.org/dwc/terms/day",
+      "maximum": 31,
+      "minimum": 1,
+      "examples": [
+        29
+      ]
+    },
+    "dwc:habitat": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/habitat",
+      "examples": [
+        "savanna"
+      ],
+      "$comment": "Is this necessary for specimens"
+    },
+    "eco:protocolDescriptions": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/eco/terms/protocolDescriptions",
+      "examples": [
+        "Three conventional harp traps (3.2m ht x 2.2m w) were established in flight path zones for a period of 4 hrs at dawn and dusk for a total of 10 trap nights. Traps were visited on an hourly basis during each deployment period and the trap catch recorded for species, size, weight, sex, age and maternal status."
+      ]
+    },
+    "dwc:sampleSizeValue": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/sampleSizeValue",
+      "examples": [
+        "5"
+      ]
+    },
+    "dwc:sampleSizeUnit": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/sampleSizeUnit",
+      "examples": [
+        "meters"
+      ]
+    },
+    "dwc:samplingProtocol": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/samplingProtocol",
+      "examples": [
+        "collected directly from the wild"
+      ]
+    },
+    "ods:eventEffort": {
+      "type": "string",
+      "comment": "Not sure what this field means"
+    },
+    "dwc:fieldNotes": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/fieldNotes",
+      "examples": [
+        "Notes available in the Grinnell-Miller Library"
+      ]
+    },
+    "dwc:eventRemarks": {
+      "type": "string",
+      "description": "https://rs.tdwg.org/dwc/terms/eventRemarks",
+      "examples": [
+        "After the recent rains the river is nearly at flood stage"
+      ]
+    },
+    "ods:collectorName": {
+      "type": "string",
+      "$comment": "Not part of DWC or the UM?"
+    },
+    "ods:collectorId": {
+      "type": "string",
+      "$comment": "Not part of DWC or the UM?"
+    },
+    "ods:Assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Assertion": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/assertions.json"
+        }
+      }
+    },
+    "dcterms:Location": {
+      "type": "object",
+      "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/digital-specimens/location.json"
+    }
+  }
+}

--- a/data-model/fdo-types/0.3.0/shared-models/schema/agent.json
+++ b/data-model/fdo-types/0.3.0/shared-models/schema/agent.json
@@ -1,0 +1,78 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/fdo-types/0.3.0/shared-models/agent.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "ods:agentRole": {
+      "type": "string",
+      "description": "Indicates the role of the agent",
+      "examples": [
+        "collector",
+        "preparer",
+        "identifier",
+        "recorder"
+      ]
+    },
+    "ods:agentType": {
+      "type": "string",
+      "description": "Indicates the type of agent",
+      "examples": [
+        "machine",
+        "human",
+        "organisation"
+      ]
+    },
+    "ods:agentId":{
+      "type": "string",
+      "description": "Primary identifier of the agent, additional identifiers can go in the identifiers array",
+      "examples": [
+        "https://orcid.org/0000-0002-1825-0097"
+      ]
+    },
+    "ods:agentName": {
+      "type": "string",
+      "description": "Full name of the agent",
+      "examples": [
+        "John Smith"
+      ]
+    },
+    "ods:agentRoleBegan": {
+      "type": "string",
+      "description": "Date the agent began the role",
+      "examples": [
+        "2023-10-02T12:31:34.806Z"
+      ]
+    },
+    "ods:agentRoleEnded": {
+      "type": "string",
+      "description": "Date the agent ended the role",
+      "examples": [
+        "2023-09-02T12:31:34.806Z"
+      ]
+    },
+    "ods:agentRoleOrder": {
+      "type": "integer",
+      "description": "Order of the agent in the role. Can be used to indicate the order of importance",
+      "minimum": 1,
+      "examples": [
+        1,
+        2
+      ]
+    },
+    "ods:Identifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "ods:Identifier": {
+          "type": "object",
+          "$ref": "https://schemas.dissco.tech/schemas/digitalobjects/0.3.0/shared-models/identifiers.json"
+        }
+      }
+    }
+  },
+  "required": [
+    "ods:agentRole",
+    "ods:agentType",
+    "ods:agentName"
+  ]
+}

--- a/data-model/fdo-types/0.3.0/shared-models/schema/assertions.json
+++ b/data-model/fdo-types/0.3.0/shared-models/schema/assertions.json
@@ -1,0 +1,44 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/fdo-types/0.3.0/shared-models/assertions.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "$comment": "Annotation Version 0.3.0",
+  "properties": {
+    "ods:assertionType": {
+      "type": "string"
+    },
+    "ods:assertionMadeDate": {
+      "type": "string"
+    },
+    "ods:assertionEffectiveDate": {
+      "type": "string"
+    },
+    "ods:assertionValue": {
+      "type": "string"
+    },
+    "ods:assertionValueNumeric": {
+      "type": "integer"
+    },
+    "ods:assertionUnit": {
+      "type": "string"
+    },
+    "ods:assertionByAgentName": {
+      "type": "string"
+    },
+    "ods:assertionByAgentId": {
+      "type": "string"
+    },
+    "ods:assertionProtocol": {
+      "type": "string"
+    },
+    "ods:assertionProtocolId": {
+      "type": "string"
+    },
+    "ods:assertionRemarks": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "ods:assertionType"
+  ]
+}

--- a/data-model/fdo-types/0.3.0/shared-models/schema/citations.json
+++ b/data-model/fdo-types/0.3.0/shared-models/schema/citations.json
@@ -1,0 +1,61 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/fdo-types/0.3.0/shared-models/citations.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "dcterms:type": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/type"
+    },
+    "dcterms:date": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/date"
+    },
+    "dcterms:title": {
+      "type": "string",
+      "description": "https://purl.org/dc/terms/title"
+    },
+    "dcterms:creator": {
+      "type": "string",
+      "description": "https://purl.org/dc/elements/1.1/creator"
+    },
+    "ods:citationPageNumber": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "ods:citationRemarks": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "ods:referenceType": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "dcterms:bibliographicCitation": {
+      "type": "string",
+      "description": "https://dublincore.org/usage/terms/history/#bibliographicCitation-002",
+      "example": [
+        "https://www.gbif.org/species/2439608 Source: GBIF Taxonomic Backbone"
+      ]
+    },
+    "ods:referenceYear": {
+      "type": "string",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "ods:referenceIri": {
+      "type": "string",
+      "format": "iri",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    },
+    "ods:isPeerReviewed": {
+      "type": "boolean",
+      "description": "Unclear yet",
+      "$comment": "Unknown what this field should be"
+    }
+  }
+}

--- a/data-model/fdo-types/0.3.0/shared-models/schema/entity-relationships.json
+++ b/data-model/fdo-types/0.3.0/shared-models/schema/entity-relationships.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/fdo-types/0.3.0/shared-models/entity-relationships.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "ods:entityRelationshipType": {
+      "type": "string"
+    },
+    "ods:objectEntityIri": {
+      "type": "string",
+      "format": "iri",
+      "description": "The link to the referenced resource. This could be an internal object linked through the PID or an external object"
+    },
+    "ods:entityRelationshipDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The data time on which the relationship was established"
+    },
+    "ods:entityRelationshipOrder": {
+      "type": "integer",
+      "description": "When multiple relationships are added an order can be defined"
+    },
+    "ods:entityRelationshipCreatorName": {
+      "type": "string",
+      "description": "The name of the relationship creator",
+      "$comment": "Not available in GBIF UM"
+    },
+    "ods:entityRelationshipCreatorId": {
+      "type": "string",
+      "description": "The PID of the creator, this could be a Orcid(user), PID(machine) or ROR(organisation)",
+      "$comment": "Not available in GBIF UM"
+    }
+  },
+  "required": [
+    "ods:entityRelationshipType",
+    "ods:objectEntityIri",
+    "ods:entityRelationshipDate",
+    "ods:entityRelationshipCreatorId"
+  ]
+}

--- a/data-model/fdo-types/0.3.0/shared-models/schema/identifiers.json
+++ b/data-model/fdo-types/0.3.0/shared-models/schema/identifiers.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://schemas.dissco.tech/schemas/fdo-types/0.3.0/shared-models/identifiers.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "ods:identifierType": {
+      "type": "string",
+      "description": "The type of the identifier",
+      "examples": [
+        "dwc:catalogueNumber",
+        "dwca:id"
+      ]
+    },
+    "ods:identifierValue":{
+      "type": "string",
+      "description": "The value for the identifier",
+      "examples": [
+        "BMNH(E)1902475",
+        "RGM.800315"
+      ]
+    },
+    "ods:partOfLabel": {
+      "type": "boolean",
+      "description": "Is the identifier part of the physical label"
+    },
+    "ods:barcodeOrNfc": {
+      "type": "string",
+      "description": "Part of barcode or nfc chip"
+    },
+    "ods:isIdPersistent": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "ods:identifierValue"
+  ]
+}


### PR DESCRIPTION
## ODS Prefix
ODS prefix for all terms which still weren't assigned to a ontology.

## Updated arrays to be plural
We decided to update the arrays to be plural, in line with recommendated practices.
This means that where Darwin Core Classes where available we wrapped this by an ods term with the plural.
For example, `dwc:Identification` becomes wrapped in `ods:Identifications` which now contains zero or more instances of `dwc:Identification`.
The tradeoff is that we added an additional layer of nesting, but we believe this is worth it to keep the terms in line with the Darwin Core standard.

## Other
Small changes in description for some terms.
dwc:institutionName is not a Darwin Core term, converted to ods:institutionName. 


https://naturalis.atlassian.net/browse/DD-1165
https://naturalis.atlassian.net/browse/DD-1186