### PR TITLE
Add sourceSystemName and other minor changed

### DIFF
--- a/data-model/fdo-type/create-update-tombstone-event/0.3.0/examples/create-event-example.json
+++ b/data-model/fdo-type/create-update-tombstone-event/0.3.0/examples/create-event-example.json
@@ -1,7 +1,7 @@
 {
-  "@id": "https://doi.org/TEST/PGD-QGK-S0R/1",
+  "@id": "https://hdl.handle.net/20.5000.1025/ABC-DEF-GHI/1",
   "@type": "ods:CreateUpdateTombstoneEvent",
-  "ods:ID": "https://doi.org/TEST/PGD-QGK-S0R/1",
+  "ods:ID": "https://hdl.handle.net/20.5000.1025/ABC-DEF-GHI/1",
   "ods:type": "https://doi.org/10.15468/1a2b3c",
   "prov:Activity": {
     "@id": "7ba628d4-2e28-4ce4-ad1e-e99c97c20507",
@@ -21,16 +21,16 @@
       }
     ],
     "prov:endedAtTime": "2024-06-11T09:14:00.348Z",
-    "prov:used": "https://doi.org/10.15468/1a2b3c/3",
+    "prov:used": "https://hdl.handle.net/20.5000.1025/ABC-DEF-GHI/1",
     "rdfs:comment": "This activity was created by the user",
     "ods:changeValue": []
   },
   "prov:Entity": {
-    "@id": "https://doi.org/TEST/PGD-QGK-S0R/1",
-    "@type": "ods:DigitalSpecimen",
+    "@id": "https://hdl.handle.net/20.5000.1025/ABC-DEF-GHI/1",
+    "@type": "ods:DataMapping",
     "prov:value": {
       "@id": "https://hdl.handle.net/20.5000.1025/ABC-DEF-GHI",
-      "@type": "ods:Mapping",
+      "@type": "ods:DataMapping",
       "ods:ID": "https://hdl.handle.net/20.5000.1025/ABC-DEF-GHI",
       "ods:type": "https://doi.org/10.15468/1a2b3c",
       "schema:version": 1,

--- a/data-model/fdo-type/digital-media/0.3.0/examples/digital-media-example.json
+++ b/data-model/fdo-type/digital-media/0.3.0/examples/digital-media-example.json
@@ -10,6 +10,7 @@
   "dcterms:type": "Image",
   "ac:accessURI": "https://example.org/digital-object/12345",
   "ods:sourceSystemID": "https://hdl.handle.net/SANDBOX/CS1-ZKQ-NZ7",
+  "ods:sourceSystemName": "Naturalis Biodiversity Center (NL) - Aves",
   "ods:organisationID": "https://ror.org/015hz7p22",
   "ods:organisationName": "National Museum of Natural History",
   "dcterms:format": "image/jpeg",

--- a/data-model/fdo-type/digital-media/0.3.0/schema/digital-media.json
+++ b/data-model/fdo-type/digital-media/0.3.0/schema/digital-media.json
@@ -93,6 +93,13 @@
       "description": "The handle to the source system object which retrieved the data from the CMS",
       "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}"
     },
+    "ods:sourceSystemName": {
+      "type": "string",
+      "description": "The name of the source system as provided to DiSSCo",
+      "examples": [
+        "Naturalis Biodiversity Center (NL) - Vermes"
+      ]
+    },
     "ods:organisationID": {
       "type": "string",
       "description": "ROR or Wikidata identifie of the organisation",

--- a/data-model/fdo-type/digital-specimen/0.3.0/examples/digital-specimen-bare.json
+++ b/data-model/fdo-type/digital-specimen/0.3.0/examples/digital-specimen-bare.json
@@ -16,6 +16,7 @@
   "ods:isKnownToContainMedia": true,
   "ods:specimenName": "Pitta versicolor Swainson, 1825",
   "ods:sourceSystemID": "https://hdl.handle.net/SANDBOX/CS1-ZKQ-NZ7",
+  "ods:sourceSystemName": "Naturalis Biodiversity Center (NL) - Aves",
   "ods:livingOrPreserved": "Preserved",
   "dcterms:license": "CC0 1.0",
   "dwc:basisOfRecord": "PreservedSpecimen",

--- a/data-model/fdo-type/digital-specimen/0.3.0/schema/digital-specimen.json
+++ b/data-model/fdo-type/digital-specimen/0.3.0/schema/digital-specimen.json
@@ -153,6 +153,13 @@
       "description": "The handle to the source system object which retrieved the data from the CMS",
       "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}"
     },
+    "ods:sourceSystemName": {
+      "type": "string",
+      "description": "The name of the source system as provided to DiSSCo",
+      "examples": [
+        "Naturalis Biodiversity Center (NL) - Vermes"
+      ]
+    },
     "ods:livingOrPreserved": {
       "description": "Whether the specimen is living or preserved",
       "enum": [

--- a/data-model/fdo-type/source-system/0.3.0/schema/source-system.json
+++ b/data-model/fdo-type/source-system/0.3.0/schema/source-system.json
@@ -8,7 +8,7 @@
     "@id": {
       "type": "string",
       "description": "The unique identifier (handle) of the Source System object",
-      "pattern": "^https://hdl\\.handle\\.net/[\\w.]+/(.){3}-(.){3}-(.){3}",
+      "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}",
       "examples": [
         "https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX"
       ]
@@ -21,7 +21,7 @@
     "ods:ID": {
       "type": "string",
       "description": "Handle of the Source System",
-      "pattern": "^https://hdl\\.handle\\.net/[\\w.]+/(.){3}-(.){3}-(.){3}",
+      "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}",
       "examples": [
         "https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX"
       ]
@@ -29,7 +29,7 @@
     "ods:type": {
       "type": "string",
       "description": "The DOI to the FDO type of the object",
-      "pattern": "^https://doi\\.org/[\\w\\.]+/[\\w\\.]+",
+      "pattern": "^https:\/\/doi\\.org/[\\w\\.]+/[\\w\\.]+",
       "examples": [
         "https://doi.org/10.15468/1a2b3c"
       ]
@@ -107,7 +107,7 @@
     "ods:dataMappingID": {
       "type": "string",
       "description": "The Handle of the Mapping Object needed for this Source System",
-      "pattern": "^https://hdl\\.handle\\.net/[\\w.]+/(.){3}-(.){3}-(.){3}",
+      "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}",
       "examples": [
         "https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX"
       ]

--- a/data-model/fdo-type/source-system/0.3.0/schema/source-system.json
+++ b/data-model/fdo-type/source-system/0.3.0/schema/source-system.json
@@ -8,7 +8,7 @@
     "@id": {
       "type": "string",
       "description": "The unique identifier (handle) of the Source System object",
-      "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}",
+      "pattern": "^https://hdl\\.handle\\.net/[\\w.]+/(.){3}-(.){3}-(.){3}",
       "examples": [
         "https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX"
       ]
@@ -21,7 +21,7 @@
     "ods:ID": {
       "type": "string",
       "description": "Handle of the Source System",
-      "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}",
+      "pattern": "^https://hdl\\.handle\\.net/[\\w.]+/(.){3}-(.){3}-(.){3}",
       "examples": [
         "https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX"
       ]
@@ -29,7 +29,7 @@
     "ods:type": {
       "type": "string",
       "description": "The DOI to the FDO type of the object",
-      "pattern": "^https:\/\/doi\\.org\/[\\w\\.]+/[\\w\\.]+",
+      "pattern": "^https://doi\\.org/[\\w\\.]+/[\\w\\.]+",
       "examples": [
         "https://doi.org/10.15468/1a2b3c"
       ]
@@ -107,7 +107,7 @@
     "ods:dataMappingID": {
       "type": "string",
       "description": "The Handle of the Mapping Object needed for this Source System",
-      "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}",
+      "pattern": "^https://hdl\\.handle\\.net/[\\w.]+/(.){3}-(.){3}-(.){3}",
       "examples": [
         "https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX"
       ]
@@ -126,9 +126,9 @@
     "schema:dateCreated",
     "schema:dateModified",
     "schema:creator",
-    "schema:uri",
+    "schema:url",
     "ods:translatorType",
-    "ods:mappingID"
+    "ods:dataMappingID"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
- Adding SourceSystemName to openDS because we need it when we create annotations and CreateUpdateTombstoneEvents. The SourceSystem is often the agent of these actions (creating new specimen for example) we want to store the identifier (PID), a human readable name for the system and the type (as:Application) for the agent.
- This will also help aggregation, for which we also proposed this change. You would now be able to filter on a specific sourcesystem (Dataset in GBIF).
https://naturalis.atlassian.net/browse/DD-1327

Fixed required fields in dataMapping
Also some minor example updates to be more in line with reality.