### PR TITLE
An agent name can not always be guaranteed

### DIFF
--- a/data-model/fdo-type/shared-model/0.3.0/schema/agent.json
+++ b/data-model/fdo-type/shared-model/0.3.0/schema/agent.json
@@ -84,8 +84,7 @@
     }
   },
   "required": [
-    "@type",
-    "schema:name"
+    "@type"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
Discussed with team, an agent name can not always be guaranteed.
This attribute can not be set to a required field. 