### PR TITLE
Add optional field ods:maximumRecords to SourceSystem

### DIFF
--- a/data-model/fdo-type/source-system/0.3.0/schema/source-system.json
+++ b/data-model/fdo-type/source-system/0.3.0/schema/source-system.json
@@ -107,7 +107,7 @@
     "ods:maximumRecords": {
       "type": "integer",
       "minimum": 1,
-      "description": "An optional parameter to limit the number of records to be ingested from this sourceSystem, it will pick the first X number of records it encounters. If left empty or absent t will process all records."
+      "description": "An optional parameter to limit the number of records to be ingested from this sourceSystem, it will pick the first X number of records it encounters. If left empty or absent it will process all records."
     },
     "ods:dataMappingID": {
       "type": "string",

--- a/data-model/fdo-type/source-system/0.3.0/schema/source-system.json
+++ b/data-model/fdo-type/source-system/0.3.0/schema/source-system.json
@@ -104,6 +104,11 @@
         "biocase"
       ]
     },
+    "ods:maximumRecords": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "An optional parameter to limit the number of records to be ingested from this sourceSystem, it will pick the first X number of records it encounters. If left empty or absent t will process all records."
+    },
     "ods:dataMappingID": {
       "type": "string",
       "description": "The Handle of the Mapping Object needed for this Source System",


### PR DESCRIPTION
Add additional field to set a maximum to the amount of Records to process.
This can be used for testing purposes, but can also be used to limit the amount of DOIs created.
Has also been suggested by Matthias in one of the demo's.
It is optional, if absent or `null` we will run full ingestion.