### PR TITLE
Fix long name of DiSSCo on CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >-
   metadata from this file.
 type: standard
 authors:
-  - name: Distributed Infrastructure for Scientific Collections
+  - name: Distributed System of Scientific Collections
     website: 'https://www.dissco.eu/'
 identifiers:
   - type: url


### PR DESCRIPTION
On the citation file for the repo (`CITATION.cff`), line 11 the long name of DiSSCo is wrong:

```cff
authors:
  - name: Distributed Infrastructure for Scientific Collections
    website: 'https://www.dissco.eu/'
```

5be915d changes it into:

```cff
authors:
  - name: Distributed System of Scientific Collections
    website: 'https://www.dissco.eu/'
```

